### PR TITLE
Enabled theme to be configured in book config; fixed AV embed urls when av_root_dir is set

### DIFF
--- a/RST/ODSAextensions/odsa/avembed/avembed.py
+++ b/RST/ODSAextensions/odsa/avembed/avembed.py
@@ -89,7 +89,7 @@ def embedlocal(av_path):
         if node.nodeType == node.TEXT_NODE:
           avheight=node.data
     embed.append(av_name)
-    embed.append(os.path.relpath(conf.odsa_path,conf.ebook_path) + '/' + av_path)
+    embed.append(os.path.relpath(conf.av_dir,conf.ebook_path) + '/' + av_path)
     embed.append(avwidth)
     embed.append(avheight)
     return embed

--- a/RST/ODSAextensions/odsa/odsascript/odsascript.py
+++ b/RST/ODSAextensions/odsa/odsascript/odsascript.py
@@ -44,7 +44,7 @@ class odsascript(Directive):
     def run(self):
                 
         """ Restructured text extension for including CSS and other libraries """
-        self.options['address'] = os.path.relpath(conf.odsa_path,conf.ebook_path)+'/'+ self.arguments[0] 
+        self.options['address'] = os.path.relpath(conf.av_dir,conf.ebook_path)+'/'+ self.arguments[0] 
         res = CODE % self.options 
         return [nodes.raw('', res, format='html')]
 

--- a/tools/config_validator.py
+++ b/tools/config_validator.py
@@ -163,7 +163,7 @@ def validate_config_file(config_file):
 
   required_fields = ['title', 'code_dir', 'module_origin', 'chapters']
 
-  optional_fields = ['book_dir', 'backend_address', 'av_root_dir', 'av_origin', 'glob_jsav_exer_options', 'exercises_root_dir', 'exercise_origin', 'build_JSAV', 'build_ODSA', 'allow_anonymous_credit', 'suppress_todo', 'assumes']
+  optional_fields = ['book_dir', 'backend_address', 'av_root_dir', 'av_origin', 'glob_jsav_exer_options', 'exercises_root_dir', 'exercise_origin', 'build_JSAV', 'build_ODSA', 'allow_anonymous_credit', 'suppress_todo', 'assumes', 'theme_dir', 'theme']
 
   # Ensure all required fields are present
   for field in required_fields:

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -319,12 +319,12 @@ html_translator_class = 'html5.HTMLTranslator'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-sys.path.append(os.path.abspath('_themes'))
-html_theme_path = ['%(odsa_root)sRST/source/_themes']
+sys.path.append('%(theme_dir)s')
+html_theme_path = ['%(theme_dir)s']
 if on_slides:
    html_theme = 'slides'
 else:
-   html_theme = 'haiku'
+   html_theme = '%(theme)s'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -696,6 +696,11 @@ def set_defaults(conf_data):
   if 'book_dir' not in conf_data:
     conf_data['book_dir'] = 'Books'
 
+  if 'theme_dir' not in conf_data:
+    conf_data['theme_dir'] = '%sRST/source/_themes'%odsa_dir
+  if 'theme' not in conf_data:
+    conf_data['theme'] = 'haiku'
+
   # If no backend address is specified, use an empty string to specify a disabled server
   if 'backend_address' not in conf_data:
     conf_data['backend_address'] = ''
@@ -863,6 +868,8 @@ def configure(config_file, slides = False):
   options['book_name'] = conf_data['name']
   options['server_url'] = conf_data['backend_address']
   options['module_origin'] = conf_data['module_origin']
+  options['theme_dir'] = conf_data['theme_dir']
+  options['theme'] = conf_data['theme']
   options['odsa_root'] = odsa_dir
   options['output_dir'] = output_dir
   options['rel_ebook_path'] = rel_ebook_path


### PR DESCRIPTION
This commit adds book configuration options `theme` and `theme_dir` which, as the names suggest, make it possible to change the theme directory and the theme name through the book configuration. By default, the values that were used previously are used (haiku and RST/source/_themes).
In addition this fixes the paths to AVs/Exercises if the av_root_dir is specified in the configuration.

Since I'm no expert on the configuration process I didn't want to directly commit this to the repository. Hopefully someone can look through this and merge if it's okay. I'm happy to make changes if required.
