### PR TITLE
Automatic handling of slashes on linked list nodes with null next/pre…

### DIFF
--- a/AV/List/dlistAppendCON.js
+++ b/AV/List/dlistAppendCON.js
@@ -22,8 +22,6 @@ $(document).ready(function () {
   var l = av.ds.dlist({nodegap: 30, center: false, left: leftMargin, top: topMargin});
   l.addFirst("null").addFirst(10).addFirst(35).addFirst(8).addFirst(23).addFirst("null");
   l.layout();
-  l.get(0).addSlash("left");
-  var tailSlash = l.get(5).addSlash();
   var Vline = l.get(5).addVLine();
   var Vline1 = l.get(5).addVLine({ left: l.get(2).element.outerWidth() / 2 + 15 });
   var Vline2 = l.get(5).addVLine({ top: 25 });
@@ -56,10 +54,8 @@ $(document).ready(function () {
   l.get(6).edgeToPrev().hide();
   l.layout({ updateTop: false });
   var longEdge = addEdge(l.get(4), l.get(6));
-  tailSlash.hide();
   Vline.hide();
   Vline1.show();
-  var newTailSlash = l.get(6).addSlash();
   pseudo.setCurrentLine("setPrev");
   av.step();
 

--- a/AV/List/dlistDiagramCON.js
+++ b/AV/List/dlistDiagramCON.js
@@ -14,7 +14,5 @@ $(document).ready(function () {
   setPointer("head", l.get(0));
   setPointer("curr", l.get(2));
   setPointer("tail", l.get(5));
-  l.get(0).addSlash("left");
-  l.get(5).addSlash();
   l.get(2).addVLine();
 });

--- a/AV/List/dlistInsertCON.js
+++ b/AV/List/dlistInsertCON.js
@@ -24,8 +24,6 @@ $(document).ready(function () {
   var l = av.ds.dlist({nodegap: 30, center: false, left: leftMargin, top: topMargin});
   l.addFirst("null").addFirst(10).addFirst(35).addFirst(8).addFirst(23).addFirst("null");
   l.layout();
-  l.get(0).addSlash("left");
-  var tailSlash = l.get(5).addSlash();
   var Vline = l.get(2).addVLine();
   var Vline1 = l.get(2).addVLine({ left: l.get(2).element.outerWidth() });
   var Vline2 = l.get(2).addVLine({ top: 25 });
@@ -58,10 +56,8 @@ $(document).ready(function () {
   l.get(3).edgeToPrev().hide();
   l.layout({ updateTop: false });
   var longEdge = addEdge(l.get(1), l.get(3));
-  tailSlash.hide();
   Vline.hide();
   Vline1.show();
-  var newTailSlash = l.get(6).addSlash();
   pseudo.setCurrentLine("new");
   av.step();
 

--- a/AV/List/dlistPrevCON.js
+++ b/AV/List/dlistPrevCON.js
@@ -19,8 +19,6 @@ $(document).ready(function () {
   var l = av.ds.dlist({nodegap: 30, center: false, left: leftMargin, top: topMargin});
   l.addFirst("null").addFirst(10).addFirst(35).addFirst(8).addFirst(23).addFirst("null");
   l.layout();
-  l.get(0).addSlash("left");
-  var tailSlash = l.get(5).addSlash();
   var Vline = l.get(3).addVLine();
   var Vline1 = l.get(2).addVLine();
   Vline1.hide();

--- a/AV/List/dlistRemoveCON.js
+++ b/AV/List/dlistRemoveCON.js
@@ -24,8 +24,6 @@ $(document).ready(function () {
   var l = av.ds.dlist({nodegap: 30, center: false, left: leftMargin, top: topMargin});
   l.addFirst("null").addFirst(35).addFirst(8).addFirst(23).addFirst("null");
   l.layout();
-  l.get(0).addSlash("left");
-  var tailSlash = l.get(4).addSlash();
   var Vline = l.get(2).addVLine();
   var Vline1 = l.get(2).addVLine({left: l.get(2).element.outerWidth() / 2 + 15, top: -35});
   var Vline2 = l.get(2).addVLine({ top: 25 });
@@ -94,8 +92,6 @@ $(document).ready(function () {
   l.layout();
   dashLineTop.hide();
   dashLineDown.hide();
-  tailSlash.hide();
-  var newTailSlash = l.get(3).addSlash();
   Vline.show();
   pseudo.setCurrentLine("size");
   av.step();

--- a/AV/List/llistBadCON.js
+++ b/AV/List/llistBadCON.js
@@ -12,8 +12,6 @@ $(document).ready(function () {
   l.addFirst(15).addFirst(12).addFirst(10).addFirst(23).addFirst(20);
   l.layout();
   var bar = l.get(2).addVLine();
-  var slash = l.get(4).addTail();
-  var slash3 = l.get(3).addTail({visible: 0}); //Diagonal slash in step 3, hide for now
 
   // Set up the various pointers
   var head = av.pointer("head", l.get(0));
@@ -35,8 +33,6 @@ $(document).ready(function () {
   av.step();
 
   // Slide 3
-  slash.hide();
-  slash3.show();
   l.remove(2);
   l.layout();
   av.umsg(interpret("av_c3"));

--- a/AV/List/llistBadDelCON.js
+++ b/AV/List/llistBadDelCON.js
@@ -18,8 +18,6 @@ $(document).ready(function () {
   var tail = setPointerL("tail", l.get(4));
   var bar = l.get(2).addVLine();
   var bar2 = l.get(3).addVLine({visible: 0});
-  var slash = l.get(4).addTail();
-  var slash6 = l.get(3).addTail({visible: 0}); // Diagonal slash in step 6
   var dashlineLeftMargin = 452;    // Dash line in step 4
   var dashline = av.g.polyline([[dashlineLeftMargin, 66],
                                 [dashlineLeftMargin + 13, 66],
@@ -65,8 +63,6 @@ $(document).ready(function () {
   dashline.hide();
   l.remove(3);
   l.get(2).edgeToNext().show();
-  slash.hide();
-  slash6.show();
   l.layout();
   av.umsg(interpret("av_c6"));
   av.step();

--- a/AV/List/llistHeaderCON.js
+++ b/AV/List/llistHeaderCON.js
@@ -11,6 +11,5 @@ $(document).ready(function () {
   setPointerL("curr", l.get(3));
   setPointerL("tail", l.get(6));
   l.get(3).addVLine();
-  l.get(6).addTail();
   av.recorded();
 });

--- a/AV/List/llistInitCON.js
+++ b/AV/List/llistInitCON.js
@@ -10,7 +10,6 @@ $(document).ready(function () {
   setPointerL("head", l.get(0));
   setPointerL("curr", l.get(1));
   setPointerR("tail", l.get(1));
-  l.get(1).addTail();
   l.get(1).addVLine();
   av.recorded();
 });

--- a/AV/List/llistInsertCON.js
+++ b/AV/List/llistInsertCON.js
@@ -22,7 +22,6 @@ $(document).ready(function () {
   var head = setPointerL("head", l.get(0));
   var curr = setPointerL("curr", l.get(2));
   var tail = setPointerL("tail", l.get(4));
-  var slash = l.get(4).addTail();
   var bar = l.get(2).addVLine();
 
   // Box "it"
@@ -32,7 +31,6 @@ $(document).ready(function () {
   // Create pieces for later steps
   var arr = av.ds.array([""], {indexed: true});
   arr.hide();
-  var newSlash = l.get(4).addTail({left: 74, top: 0, visible: 0});
   //Horizontal arrow in step 4 pointing to item 12
   var longArrow = av.g.line(leftMargin + 190, topMargin + 31,
                             leftMargin + 298, topMargin + 31,
@@ -55,8 +53,6 @@ $(document).ready(function () {
   l.get(2).edgeToNext().hide();
   l.get(3).edgeToNext().hide();
   longArrow.show();
-  slash.hide();
-  newSlash.show();
   l.layout({ updateTop: false });
   av.umsg(interpret("av_c2"));
   //Copy 23 to the new link node

--- a/AV/List/llistOtherCON.js
+++ b/AV/List/llistOtherCON.js
@@ -19,7 +19,6 @@ $(document).ready(function () {
   temp.hide();
   var nextCurr = setPointerL("curr", l.get(4));
   nextCurr.hide();
-  var slash = l.get(5).addTail(); // Diagonal slash at end
 
   var pseudo_next = av.code($.extend({left: 80, top: 150,
                                       visible: false, lineNumbers: false}, code[0]));

--- a/AV/List/llistRemoveCON.js
+++ b/AV/List/llistRemoveCON.js
@@ -23,9 +23,6 @@ $(document).ready(function () {
   var curr = setPointerL('curr', l.get(2));
   var tail = setPointerL('tail', l.get(5));
   var verticalBar = l.get(2).addVLine();
-  var slash = l.get(5).addTail();
-  // New slash after deletion
-  var newSlash = l.get(4).addTail({ visible: 0 });
 
   // Dashline
   var dashline = av.g.polyline([[leftMargin + 186, topMargin + 32],
@@ -88,8 +85,6 @@ $(document).ready(function () {
   dashline.hide();
   l.layout();
   l.get(2).edgeToNext().show();
-  slash.hide();
-  newSlash.show();
   l.get(2).unhighlight();
   l.get(3).unhighlight();
   av.umsg(interpret("av_c6"));

--- a/AV/List/llistRepCON.js
+++ b/AV/List/llistRepCON.js
@@ -5,7 +5,6 @@ $(document).ready(function () {
   var av = new JSAV("llistRepCON", {animationMode: "none"});
   var l = av.ds.list({nodegap: 30});
   l.addFirst("").addFirst("").addFirst("");
-  l.get(2).addTail({left: 477});
   l.layout();
   av.recorded();
 });

--- a/AV/List/llistSpecialCON.js
+++ b/AV/List/llistSpecialCON.js
@@ -30,23 +30,6 @@ $(document).ready(function () {
   var curr = setPointerL("curr", l.get(2));
   var tail = setPointerR("tail", l.get(2));
   var bar1 = l.get(2).addVLine();
-  var slash = l.get(2).addTail();
-
-  //Diagonal slash for new node
-  var newNodeSlash = av.g.line(leftMargin + 256, topMargin + 100,
-                               leftMargin + 266, topMargin + 71,
-                               {"opacity": 0, "stroke-width": 1});
-
-  //Diagonal slash for new tail
-  var newTailSlash = l.get(2).addTail({left: 74, visible: 0});
-
-  //Diagonal slash for second new node
-  var newNodeSlash2 = av.g.line(leftMargin + 182, topMargin + 100,
-                                leftMargin + 192, topMargin + 71,
-                                {"opacity": 0, "stroke-width": 1});
-
-  var slash2 = l.get(0).addTail({left: 74});
-  slash2.hide();
 
   // Slide 1
   av.umsg(interpret("av_c1"));
@@ -69,7 +52,6 @@ $(document).ready(function () {
   av.step();
 
   // Slide 4
-  newNodeSlash.show();
   av.umsg(interpret("av_c4"));
   av.step();
 
@@ -81,7 +63,6 @@ $(document).ready(function () {
   newNode.unhighlight();
   l.get(2).highlight();
   l.layout({ updateTop: false }); // Do not recalculate top coordinate
-  slash.hide();
   av.umsg(interpret("av_c5"));
   av.step();
 
@@ -94,8 +75,6 @@ $(document).ready(function () {
 
   // Slide 7
   l.layout();
-  newNodeSlash.hide();
-  newTailSlash.show();
   tail.target(l.get(3), {anchor: 'left top', myAnchor: 'right bottom',
                          left: 15, top: -20});
   l.get(2).unhighlight();
@@ -123,9 +102,7 @@ $(document).ready(function () {
   l.addFirst("null");
   bar1.hide();
   itBox.highlight(0);
-  slash2.show();
   var bar2 = l.get(0).addVLine({left: 74});
-  newTailSlash.hide();
   head.target(l.get(0));
   curr.target(l.get(1));
   tail.target(l.get(1));
@@ -147,7 +124,6 @@ $(document).ready(function () {
   av.step();
 
   // Slide 12
-  newNodeSlash2.show();
   av.umsg(interpret("av_c12"));
   av.step();
 
@@ -159,7 +135,6 @@ $(document).ready(function () {
   newNode2.unhighlight();
   l.get(1).highlight();
   l.layout({updateTop: false}); // Do not recalculate top coordinate
-  slash2.hide();
   av.umsg(interpret("av_c13"));
   av.step();
 
@@ -171,13 +146,7 @@ $(document).ready(function () {
   av.step();
 
   // Slide 15
-  //Diagonal slash for new tail
-  var newTailSlash2 = av.g.line(leftMargin + 182, topMargin + 46,
-                                leftMargin + 192, topMargin + 15,
-                                {"opacity": 0, "stroke-width": 1});
   l.layout();
-  newNodeSlash2.hide();
-  newTailSlash2.show();
   tail.target(l.get(2), {anchor: "left top", myAnchor: "right bottom",
                          left: 15, top: -20});
   l.get(1).unhighlight();

--- a/AV/List/lqueueDequeueCON.js
+++ b/AV/List/lqueueDequeueCON.js
@@ -47,9 +47,6 @@ $(document).ready(function () {
   var list = av.ds.list({nodegap: 30, left: leftMargin, top: topMargin});
   list.addFirst(30).addFirst(21).addFirst(3).addFirst("null");
   list.layout();
-  var slash1 = list.get(3).addTail();
-  var slash2 = list.get(2).addTail();
-  slash2.hide();
 
   var frontP = av.pointer("front", list.get(0));
   var rearP = av.pointer("rear", list.get(3));
@@ -85,8 +82,6 @@ $(document).ready(function () {
   list.remove(1);
   list.get(0).edgeToNext().show();
   dashLine.hide();
-  slash1.hide();
-  slash2.show();
   list.layout();
   av.step();
 

--- a/AV/List/lqueueEnqueueCON.js
+++ b/AV/List/lqueueEnqueueCON.js
@@ -18,15 +18,10 @@ $(document).ready(function () {
       .addFirst(21)
       .addFirst(3)
       .addFirst("null");
-  var slash1 = list.get(3).addTail({left: 221});
   var newNode = list.newNode("10");
   newNode.css({top: topMargin + 20});
   list.layout();
-  var slash2 = newNode.addTail({left: 295});
-  var slash3 = list.get(0).addTail({left: 295});
   newNode.hide();
-  slash2.hide();
-  slash3.hide();
 
   var frontP = av.pointer("front", list.get(0));
   var rearP = av.pointer("rear", list.get(3));
@@ -42,7 +37,6 @@ $(document).ready(function () {
   pseudo.setCurrentLine("setNext");
   newNode.show();
   newNode.highlight();
-  slash2.show();
   var endNode = list.get(3);
   endNode.next(newNode);
   endNode.edgeToNext().hide();
@@ -51,7 +45,6 @@ $(document).ready(function () {
 
   // Slide 3
   av.umsg("The <code>next</code> field of the <code>rear</code> node is assigned to point to the new node.");
-  slash1.hide();
   newNode.unhighlight();
   endNode.edgeToNext().show();
   list.layout({updateTop: false});
@@ -59,8 +52,6 @@ $(document).ready(function () {
 
   // Slide 4
   av.umsg("Advance <code>rear</code> to point to the new link node.");
-  slash2.hide();
-  slash3.show();
   list.layout();
   rearP.target(list.get(4));
   pseudo.setCurrentLine("rear");

--- a/AV/List/lqueueIntroCON.js
+++ b/AV/List/lqueueIntroCON.js
@@ -18,7 +18,6 @@ $(document).ready(function () {
       .addFirst(10)
       .addFirst(5)
       .addFirst("null");
-  var slash = list.get(3).addTail({left: 221});
   list.layout();
   var frontP = av.pointer("front", list.get(0));
   var rearP = av.pointer("rear", list.get(3));
@@ -26,12 +25,10 @@ $(document).ready(function () {
   // Would like to put this in Slide 2, but the slash doesn't hide correctly
   var listInit = av.ds.list({nodegap: 30, left: leftMargin, top: topMargin});
   listInit.addFirst("null");
-  var slashI = listInit.get(0).addTail();
   listInit.layout();
   var frontIP = setPointerL("front", listInit.get(0));
   var rearIP = setPointerR("rear", listInit.get(0));
   listInit.hide();
-  slashI.hide();
   frontIP.hide();
   rearIP.hide();
 
@@ -53,9 +50,7 @@ $(document).ready(function () {
   list.hide();
   frontP.hide();
   rearP.hide();
-  slash.hide();
   listInit.show();
-  slashI.show();
   frontIP.show();
   rearIP.show();
   av.umsg(interpret("av_c3"));
@@ -66,11 +61,9 @@ $(document).ready(function () {
   listInit.hide();
   frontIP.hide();
   rearIP.hide();
-  slashI.hide();
   list.show();
   frontP.show();
   rearP.show();
-  slash.show();
   av.umsg(interpret("av_c4"));
   av.recorded();
 });

--- a/AV/List/lstackDiagramCON.js
+++ b/AV/List/lstackDiagramCON.js
@@ -8,6 +8,5 @@ $(document).ready(function () {
   l.layout();
   //  var topPointer = setPointerL("top", l.get(0));
   var topPointer = av.pointer("top", l.get(0));
-  l.get(4).addTail();
   av.recorded();
 });

--- a/AV/List/lstackPopCON.js
+++ b/AV/List/lstackPopCON.js
@@ -19,7 +19,6 @@ $(document).ready(function () {
       .addFirst(8)
       .addFirst(23);
 
-  list.get(3).addTail({left: 222});
   var firstnode = list.get(0);
   var topPointer = av.pointer("top", firstnode);
   list.layout();

--- a/AV/List/lstackPushCON.js
+++ b/AV/List/lstackPushCON.js
@@ -18,7 +18,6 @@ $(document).ready(function () {
       .addFirst(12)
       .addFirst(8)
       .addFirst("");
-  list.get(3).addTail({left: 222});
   var newnode = list.get(0);
   newnode.edgeToNext().hide();
   newnode.hide();

--- a/DataStructures/DoubleLinkList.css
+++ b/DataStructures/DoubleLinkList.css
@@ -23,3 +23,12 @@
   max-width: 50px;
   padding-right: 0;
 }
+.jsavhorizontallist .jsavnonext .jsavrightpointerarea:after,
+.jsavhorizontallist .jsavnoprev .jsavleftpointerarea:after {
+    display: inline-block;
+    content: "";
+    height: 104%;
+    width: 1px;
+    background-color: #000;
+    transform: rotate(12deg);
+}

--- a/DataStructures/DoubleLinkList.js
+++ b/DataStructures/DoubleLinkList.js
@@ -190,7 +190,7 @@ $(document).ready(function () {
       valtype = 'string';
     }
     this.element = el;
-    el.addClass('jsavnode jsavlistnode').attr({
+    el.addClass('jsavnode jsavlistnode' + (this._next ? '' : ' jsavnonext')  + (this._prev ? '' : ' jsavnoprev')).attr({
       'data-value': value,
       'id': this._value,
       'data-value-type': valtype
@@ -216,16 +216,8 @@ $(document).ready(function () {
     JSAV.utils._helpers.handleVisibility(this, this.options);
   };
 
-  JSAV.utils.extend(DListNode, JSAV._types.ds.Node);
+  JSAV.utils.extend(DListNode, JSAV._types.ds.ListNode);
   var listnodeproto = DListNode.prototype;
-
-  listnodeproto.next = function (newNext, options) {
-    if (typeof newNext === 'undefined') {
-      return this._next;
-    } else {
-      return this._setnext(newNext, options);
-    }
-  };
 
   listnodeproto.prev = function (newPrev, options) {
     if (typeof newPrev === 'undefined') {
@@ -234,19 +226,6 @@ $(document).ready(function () {
       return this._setprev(newPrev, options);
     }
   };
-  listnodeproto._setnext = JSAV.anim(function (newNext, options) {
-    var oldNext = this._next;
-    this._next = newNext;
-    if (newNext && this._edgetonext) {
-      this._edgetonext.end(newNext);
-    } else if (newNext) {
-      this._edgetonext = new Edge(this.jsav, this, this._next, { 'arrow-end': 'classic-wide-long' });
-    }
-    if (options && options.edgeLabel) {
-      this._edgetonext.label(options.edgeLabel);
-    }
-    return [oldNext];
-  });
 
   listnodeproto._setprev = JSAV.anim(function (newPrev, options) {
     var oldPrev = this._prev;
@@ -256,11 +235,13 @@ $(document).ready(function () {
     } else if (newPrev) {
       this._edgetoprev = new Edge(this.jsav, this, this._prev, { 'arrow-end': 'classic-wide-long' });
     }
+    if (!oldPrev && newPrev) {
+      this.element.removeClass('jsavnoprev');
+    } else if (oldPrev && !newPrev) {
+      this.element.addClass('jsavnoprev');
+    }
     return [oldPrev];
   });
-  listnodeproto.edgeToNext = function () {
-    return this._edgetonext;
-  };
 
   listnodeproto.edgeToPrev = function () {
     return this._edgetoprev;


### PR DESCRIPTION
…v pointer (#280).

Commit updates JSAV to do the automatic slash handling, and cleans up the manual handling
from list, doubly linked list, queue, and stack AVs.

There could still be proficiency or KA exercises which were not cleaned. They will have two
overlapping slashes. Also, this doesn't remove the helper functions for the slash handling.