### PR TITLE
Slide Upgrade branch merge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "lib/hieroglyph"]
-	path = lib/hieroglyph
-	url = https://github.com/sublime09/hieroglyph.git
-	branch = master

--- a/Doc/source/Configuration.rst
+++ b/Doc/source/Configuration.rst
@@ -210,6 +210,11 @@ All are required unless otherwise specified.
   Any RST files not found in the indicated subdirectory will then be
   located in ``~OpenDSA/RST/en``.
 
+* **sphinx_debug** - (optional) A boolean for debugging errors that 
+  occur within sphinx while it builds books. Useful for advanced developers. 
+  It enables the -E and -P options when running sphinx to build books. It is 
+  false by default. 
+
 * **glob_mod_options** - (optional) An object containing options to be
   applied to every module in the book.
   Can be overridden by module-specific options.

--- a/Doc/source/GettingStarted.rst
+++ b/Doc/source/GettingStarted.rst
@@ -364,7 +364,7 @@ Once the repository is cloned (we assume here into a directory named
 This command will first pull and build the OpenDSA images before
 instantiating the OpenDSA container.
 This command runs several setup commands in the background to
-initialize the submodules and install the python packages requirements
+initialize the container and install the python packages requirements
 of OpenDSA.
 **This will probably take a long time to run the first time.**
 

--- a/Doc/source/ModAuthor.rst
+++ b/Doc/source/ModAuthor.rst
@@ -144,17 +144,15 @@ for that language.
 Creating Classroom Presentation Slides
 --------------------------------------
 
-At the moment, OpenDSA uses a 
-`custom hieroglyph <https://github.com/sublime09/hieroglyph/>`_ 
-extention of Sphinx to build HTML-based slideshows.  
-It is forked off of the main 
-`hieroglyph <https://github.com/nyergler/hieroglyph/>`_ repository at version
-still has issues with Sphinx versions 1.8 and above.  
+OpenDSA uses `hieroglyph <https://github.com/nyergler/hieroglyph/>`_, a Sphinx 
+extension to build HTML slideshows to view in your browser.
 
 The course notes infrastructures is similar to eTextBook creation, and uses
-``OpenDSA/Makefile``. The only difference is the ``-s`` option for slides
+``OpenDSA/Makefile``.   The only difference is the ``-s`` option for slides
 when calling the configuration, for example ``python tools/configure.py -s config/OpenDSA.json``.
-
+The Makefile will use the ``-s`` option automatically if your JSON config's 
+filename ends with the word 'slides' or 'Slides' (e.g. ``make TestSlides`` 
+will use ``config/TestSlides.json`` and create class presentation slides).
 
 Internationalization Support
 ----------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,5 @@ RUN apt-get update -qq \
 RUN mkdir /opendsa
 WORKDIR /opendsa
 
-RUN mkdir lib
-RUN git clone https://github.com/sublime09/hieroglyph.git /opendsa/lib/hieroglyph
 ADD requirements.txt /opendsa
 RUN pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ ifeq ($(strip $(ODSA_ENV)),DEV)
 	CSS_MINIFY = cat
 endif
 
+SUBMODULES_MSG = "Note: OpenDSA does not use submodules anymore\n\
+\tIn the future, 'git pull' should suffice\n\
+\tTo fully remove all submodule remains, try:\n\
+\tgit submodule deinit -f -- lib/hieroglyph JSAV OpenPOP QBank khan-exercises\n\
+\techo rm -rf .git/modules/*"
+
 
 .PHONY: clean min pull Webserver
 
@@ -30,8 +36,7 @@ Webserver:
 
 pull:
 	git pull
-	git submodule init
-	git submodule update
+	echo -e $(SUBMODULES_MSG)
 	make --silent min
 
 printEnv:

--- a/README.md
+++ b/README.md
@@ -69,12 +69,8 @@ directives that we have created.
 Exercises: Our Khan Academy Infrastructure-based exercises. Subdirectories
 divide the content by topic.
 
-JSAV: The JavaScript Algorithm Visualization library (JSAV). This is a submodule
-for the OpenDSA repository, linked to: https://github.com/vkaravir/JSAV. Thus,
-when you check out OpenDSA, you must get the JSAV submodule by either running
-the command "make pull" or by doing the following:
-  git submodule init
-  git submodule update
+JSAV: The JavaScript Algorithm Visualization library (JSAV). This is sourced
+from: https://github.com/vkaravir/JSAV and is updated occassionally.  
 More information about JSAV can be found here:
 http://jsav.io/
 
@@ -104,7 +100,7 @@ Python, and JavaScript. In this way, instructors would be able to generate
 versions of tutorials that support any or all of these three languages.
 
 **Storyboard: Materials related to "storyboarding" designs for tutorials. This
-concept never gained much traction, and this might be removed at some point.
+concept never gained much traction, and this might be removed at some point.**
 
 WebServer: A command for invoking a simple python-based web server that will
 enable you to run the Khan Academy exercises if your machine is not running a

--- a/config/Test.json
+++ b/config/Test.json
@@ -3,6 +3,7 @@
   "desc": "Test",
   "build_dir": "Books",
   "code_dir": "SourceCode/",
+  "sphinx_debug": false,
   "code_lang": {
     "Java_Generic": {
       "ext": [

--- a/config/TestSlides.json
+++ b/config/TestSlides.json
@@ -3,6 +3,7 @@
   "desc": "OpenDSA Test for slides",
   "build_dir": "Books",
   "code_dir": "SourceCode/",
+  "sphinx_debug": false,
   "lang": "en",
   "code_lang": {
     "Java": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,5 @@ beautifulsoup4==4.8.2
 xmltodict==0.12.0
 docutils==0.16
 sphinx==2.4.4
-# hieroglyph==1.0.0 # Hieroglyph 1.0.0 is does not work with newer Sphinx
-# Use this 'dirty' version of hieroglyph by sublime09 in the meantime: 
---editable lib/hieroglyph
+hieroglyph==2.1.0
 pylint==2.5.3

--- a/tools/ODSA_Config.py
+++ b/tools/ODSA_Config.py
@@ -30,7 +30,8 @@ optional_fields = ['assumes', 'av_origin', 'av_root_dir', 'build_cmap', 'build_d
 'exercise_origin', 'exercises_root_dir', 'glob_mod_options', 'glob_exer_options', 'lang','req_full_ss', 'start_chap_num',
 'suppress_todo', 'tabbed_codeinc', 'theme', 'theme_dir', 'dispModComp', 'tag', 'local_mode', 'title', 'desc', 'av_origin',
 'av_root_dir', 'code_lang', 'course_id', 'LMS_url', 'module_map', 'inst_book_id','module_position','inst_exercise_id',
-'inst_chapter_id','options','inst_module_id','id', 'total_points', 'last_compiled', 'narration_enabled', 'zeropt_assignments' ]
+'inst_chapter_id','options','inst_module_id','id', 'total_points', 'last_compiled', 'narration_enabled', 'zeropt_assignments',
+'sphinx_debug']
 
 
 listed_modules = []
@@ -332,6 +333,9 @@ def set_defaults(conf_data):
 
     if 'zeropt_assignments' not in conf_data:
         conf_data['zeropt_assignments'] = False
+
+    if 'sphinx_debug' not in conf_data:
+        conf_data['sphinx_debug'] = False
 
 def group_exercises(conf_data, no_lms):
     """group all exercises of one module in exercises attribute"""

--- a/tools/ODSA_RST_Module.py
+++ b/tools/ODSA_RST_Module.py
@@ -30,7 +30,7 @@ import datetime
 import re
 import codecs
 from string import whitespace as ws
-from config_templates import *
+import config_templates
 from collections import OrderedDict
 
 # Prints the given string to standard error
@@ -369,10 +369,10 @@ class ODSA_RST_Module:
             header_data['mod_options'] = format_mod_options(mod_options)
             header_data['build_cmap'] = str(config.build_cmap).lower()
             # Include an empty unicode directive when building slides
-            header_data['unicode_directive'] = rst_header_unicode if os.environ.get(
+            header_data['unicode_directive'] = config_templates.rst_header_unicode if os.environ.get(
                 'SLIDES', None) == "no" else ''
             # Prepend the header data to the exisiting module data
-            mod_data.insert(0, rst_header % header_data)
+            mod_data.insert(0, config_templates.rst_header % header_data)
 
             avmetadata_found = False
 
@@ -887,7 +887,7 @@ class ODSA_RST_Module:
                 pattern, "", module_name.lower().replace(' ', '-').replace('\'', '-'))
             footer_data['sections'] = [re.sub(pattern, "", sec.lower().replace(' ', '-').replace('\'', '-'))
                                        for sec in sections]
-            mod_data.insert(0, rst_footer % footer_data)
+            mod_data.insert(0, config_templates.rst_footer % footer_data)
 
             # Write the contents of the module file to the output src directory
             with codecs.open(''.join([config.book_src_dir, mod_name, '.rst']), 'w', 'utf-8') as mod_file:

--- a/tools/ODSA_RST_Module.py
+++ b/tools/ODSA_RST_Module.py
@@ -372,6 +372,10 @@ class ODSA_RST_Module:
             header_data['unicode_directive'] = config_templates.rst_header_unicode if os.environ.get(
                 'SLIDES', None) == "no" else ''
             # Prepend the header data to the exisiting module data
+
+            if os.environ.get('SLIDES', None) == "yes":
+                # implicit hyperlink from '.. _%(mod_name)s:' creates a critical error when building slides
+                config_templates.rst_header = config_templates.rst_header.replace('.. _%(mod_name)s:', '.. LINK REMOVED for slides')
             mod_data.insert(0, config_templates.rst_header % header_data)
 
             avmetadata_found = False

--- a/tools/config_templates.py
+++ b/tools/config_templates.py
@@ -1,5 +1,9 @@
 # Header prepended to every RST file, contains settings for a specific module
 rst_header = '''\
+
+.. _%(mod_name)s:
+
+
 .. raw:: html
 
    <script>ODSA.SETTINGS.DISP_MOD_COMP = %(dispModComp)s;ODSA.SETTINGS.MODULE_NAME = "%(mod_name)s";ODSA.SETTINGS.MODULE_LONG_NAME = "%(long_name)s";ODSA.SETTINGS.MODULE_CHAPTER = "%(mod_chapter)s"; ODSA.SETTINGS.BUILD_DATE = "%(mod_date)s"; ODSA.SETTINGS.BUILD_CMAP = %(build_cmap)s;%(mod_options)s</script>

--- a/tools/config_templates.py
+++ b/tools/config_templates.py
@@ -1,7 +1,5 @@
 # Header prepended to every RST file, contains settings for a specific module
 rst_header = '''\
-.. _%(mod_name)s:
-
 .. raw:: html
 
    <script>ODSA.SETTINGS.DISP_MOD_COMP = %(dispModComp)s;ODSA.SETTINGS.MODULE_NAME = "%(mod_name)s";ODSA.SETTINGS.MODULE_LONG_NAME = "%(long_name)s";ODSA.SETTINGS.MODULE_CHAPTER = "%(mod_chapter)s"; ODSA.SETTINGS.BUILD_DATE = "%(mod_date)s"; ODSA.SETTINGS.BUILD_CMAP = %(build_cmap)s;%(mod_options)s</script>

--- a/tools/config_templates.py
+++ b/tools/config_templates.py
@@ -62,6 +62,10 @@ makefile_template = '''\
 # PYTHON should match the exec of the rest of OpenDSA
 PYTHON = %(python_executable)s
 SPHINXBUILD   = sphinx-build
+SPHINXOPTS    = %(sphinx_options)s
+# -E is option to always build from new environment, regardless of changed files
+# -vv and -vvv are options for verbose build output
+# -P is for starting pdb exactly when and where exception occurs
 HTMLDIR       = %(rel_book_output_path)s
 MINIMIZE      = uglifyjs
 TAGS = %(tag)s
@@ -90,7 +94,7 @@ min-searchtools:
 	@$(MINIMIZE) $(HTMLDIR)_static/searchtools.js > $(HTMLDIR)_static/searchtools.js
 
 html:
-	$(SPHINXBUILD) $(TAGS) -b html source $(HTMLDIR)
+	$(SPHINXBUILD) $(TAGS) $(SPHINXOPTS) -b html source $(HTMLDIR)
 	rm html/_static/jquery.js
 	cp "%(odsa_dir)slib/conceptMap.html" $(HTMLDIR)
 	rm *.json
@@ -100,7 +104,7 @@ html:
 
 slides:
 	@SLIDES=yes \
-	$(SPHINXBUILD) -b slides source $(HTMLDIR)
+	$(SPHINXBUILD) $(SPHINXOPTS) -b slides source $(HTMLDIR)
 	rm html/_static/jquery.js
 	cp "%(odsa_dir)slib/styles.css" html/_static/ # Overwrites
 	rm *.json

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -41,7 +41,7 @@ import simple2full
 
 from collections.abc import Iterable
 from argparse import ArgumentParser
-from config_templates import *
+import config_templates
 from ODSA_RST_Module import ODSA_RST_Module
 from ODSA_Config import ODSA_Config
 from postprocessor import update_TOC, update_TermDef, make_lti
@@ -235,12 +235,12 @@ def generate_index_rst(config, slides=False, standalone_modules=False):
     header_data['mod_date'] = str(datetime.datetime.now()).split('.')[0]
     header_data['mod_options'] = ''
     header_data['build_cmap'] = str(config.build_cmap).lower()
-    header_data['unicode_directive'] = rst_header_unicode if not slides else ''
+    header_data['unicode_directive'] = config_templates.rst_header_unicode if not slides else ''
 
     # Generate the index.rst file
     with codecs.open(config.book_src_dir + 'index.rst', 'w+', "utf-8") as index_rst:
-        index_rst.write(index_header.format(config.start_chap_num))
-        index_rst.write(rst_header % header_data)
+        index_rst.write(config_templates.index_header.format(config.start_chap_num))
+        index_rst.write(config_templates.rst_header % header_data)
 
         # Process all the chapter and module information
         process_section(config, config.chapters, index_rst, 0, standalone_modules=standalone_modules)
@@ -278,9 +278,9 @@ def generate_todo_rst(config, slides=False):
         header_data['mod_date'] = str(datetime.datetime.now()).split('.')[0]
         header_data['mod_options'] = ''
         header_data['build_cmap'] = str(config.build_cmap).lower()
-        header_data['unicode_directive'] = rst_header_unicode if not slides else ''
-        todo_file.write(rst_header % header_data)
-        todo_file.write(todo_rst_template)
+        header_data['unicode_directive'] = config_templates.rst_header_unicode if not slides else ''
+        todo_file.write(config_templates.rst_header % header_data)
+        todo_file.write(config_templates.todo_rst_template)
 
         current_type = ''
 
@@ -324,13 +324,13 @@ def initialize_output_directory(config):
     # Create source/_static/config.js in the output directory
     # Used to set global settings for the client-side framework
     with open(config.book_src_dir + '_static/config.js', 'w') as config_js:
-        config_js.writelines(config_js_template % config)
+        config_js.writelines(config_templates.config_js_template % config)
 
     # Create an index.html page in the book directory that redirects the user
     # to the book_output_dir
     with open(config.book_dir + 'index.html', 'w') as index_html:
         index_html.writelines(
-            index_html_template % config.rel_book_output_path)
+            config_templates.index_html_template % config.rel_book_output_path)
 
 
 def initialize_conf_py_options(config, slides):
@@ -481,11 +481,11 @@ def configure(config_file_path, options):
 
     # Create a Makefile in the output directory
     with open(config.book_dir + 'Makefile', 'w') as makefile:
-        makefile.writelines(makefile_template % options)
+        makefile.writelines(config_templates.makefile_template % options)
 
     # Create conf.py file in output source directory
     with codecs.open(config.book_src_dir + 'conf.py', 'w', "utf-8") as conf_py:
-        conf_py.writelines(conf % options)
+        conf_py.writelines(config_templates.conf % options)
 
     # Copy only the images used by the book from RST/Images/ to the book
     # source directory

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -240,6 +240,9 @@ def generate_index_rst(config, slides=False, standalone_modules=False):
     # Generate the index.rst file
     with codecs.open(config.book_src_dir + 'index.rst', 'w+', "utf-8") as index_rst:
         index_rst.write(config_templates.index_header.format(config.start_chap_num))
+        if slides:
+            # implicit hyperlink from '.. _%(mod_name)s:' creates a critical error when building slides
+            config_templates.rst_header = config_templates.rst_header.replace('.. _%(mod_name)s:', '.. removed from slides: .. _%(mod_name)s:')
         index_rst.write(config_templates.rst_header % header_data)
 
         # Process all the chapter and module information
@@ -279,6 +282,10 @@ def generate_todo_rst(config, slides=False):
         header_data['mod_options'] = ''
         header_data['build_cmap'] = str(config.build_cmap).lower()
         header_data['unicode_directive'] = config_templates.rst_header_unicode if not slides else ''
+        if slides:
+            # implicit hyperlink from '.. _%(mod_name)s:' creates a critical error when building slides
+            config_templates.rst_header = config_templates.rst_header.replace('.. _%(mod_name)s:', '.. removed from slides: .. _%(mod_name)s:')
+            
         todo_file.write(config_templates.rst_header % header_data)
         todo_file.write(config_templates.todo_rst_template)
 

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -354,7 +354,10 @@ def initialize_conf_py_options(config, slides):
     options['tabbed_code'] = config.tabbed_codeinc
     options['code_lang'] = json.dumps(config.code_lang)
     options['text_lang'] = json.dumps(config.lang)
-
+    if config.sphinx_debug:
+        options['sphinx_options'] = '-E -P'
+    else:
+        options['sphinx_options'] = ''
 
     #Adding multiple tags support
     if config.tag:


### PR DESCRIPTION
These are the changes to remove the 'dirty' and custom hieroglyph v1.1 (modified to support the newer sphinx version) and instead use the new and official hieroglyph v2.1 (which already supports newer sphinx).  Some of ODSA's code needed to change because of the custom RST changes we make while building the slideshow books.  

This is also the end of all submodules.  So even the .gitmodules file is deleted.  Rejoice!

This also shows a new field that can be added to the JSON configs for books.  'sphinx_debug' is optional and is false by default, but can be enabled to quickly open up pdb (python's debugger) at the moment a sphinx error happens.  Without it, when sphinx finds an error, it quits the book-building process and the error messages are not always helpful.  This helped me while tracking down the ODSA fixes I needed, but we can revert that change easily if we don't want to add that to the config JSONs.  I updated the Docs with this info as well.  