### PR TITLE
Typo in the first option for hashing question in the Bucket Hashing module

### DIFF
--- a/Exercises/Hashing/HashMCQhashdef.html
+++ b/Exercises/Hashing/HashMCQhashdef.html
@@ -14,7 +14,7 @@
           <p class="question">A hash function must:</p>
           <div class="solution">Return a value between 0 and <code>M-1</code></div>
           <ul class="choices" data-show="4">
-            <li>Return a value betwen 1 and <code>M</code></li>
+            <li>Return a value between 1 and <code>M</code></li>
             <li>Return the position of a free slot in the table</li>
             <li>Return the hash value for the key</li>
             <li>Return values in equal distribution throughout the table</li>


### PR DESCRIPTION
This hash function question has a typo in the word "between".