### PR TITLE
changes to support custom sphinx themes (example in Test.json; needs …

### DIFF
--- a/RST/_static/renku-book.css
+++ b/RST/_static/renku-book.css
@@ -1,0 +1,24 @@
+#site-navigation.single-page { display: none; }
+body, .heading-style, h1, h2, h3, h4, h5, h6 { font-family: 'Raleway'; }
+body { font-size: 17px; }
+h2 { border-bottom: 1px solid #ccc; }
+
+.codeWrapper pre { margin-top: 0; }
+
+div.topic {
+    padding: 1em 1em 2px 1em;
+    margin-bottom: 1em;
+}
+p.topic-title {
+    font-size: 1.1em;
+    font-weight: bold;
+    border-bottom: 1px solid #ccc;
+}
+.jsavcontainer { border: 1px solid #ccc; }
+.line-block { display: block; margin-top: 1em; margin-bottom: 1em; }
+.line-block .line-block {
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: 1.5em;
+}
+.prev-next-bottom { display: none; }

--- a/config/Test.json
+++ b/config/Test.json
@@ -1,6 +1,13 @@
 {
   "title": "Test",
   "desc": "Test",
+  "theme": "sphinx_book_theme",
+  "html_theme_options": {
+    "use_download_button": false,
+    "single_page": true
+  },
+  "html_css_files": ["_static/renku-book.css"],
+  "html_js_files": ["_static/sphinx-book-theme.12a9622fbb08dcb3a2a40b2c02b83a57.js"],
   "build_dir": "Books",
   "code_dir": "SourceCode/",
   "sphinx_debug": false,

--- a/tools/ODSA_Config.py
+++ b/tools/ODSA_Config.py
@@ -31,7 +31,7 @@ optional_fields = ['assumes', 'av_origin', 'av_root_dir', 'build_cmap', 'build_d
 'suppress_todo', 'tabbed_codeinc', 'theme', 'theme_dir', 'dispModComp', 'tag', 'local_mode', 'title', 'desc', 'av_origin',
 'av_root_dir', 'code_lang', 'course_id', 'LMS_url', 'module_map', 'inst_book_id','module_position','inst_exercise_id',
 'inst_chapter_id','options','inst_module_id','id', 'total_points', 'last_compiled', 'narration_enabled', 'zeropt_assignments',
-'sphinx_debug']
+'sphinx_debug', 'html_theme_options', 'html_css_files', 'html_js_files']
 
 
 listed_modules = []

--- a/tools/config_templates.py
+++ b/tools/config_templates.py
@@ -129,6 +129,7 @@ conf = '''\
 # serve to show the default.
 
 import sys, os
+import json
 
 #checking if we are building a book or class notes (slides)
 on_slides = os.environ.get('SLIDES', None) == "yes"
@@ -269,7 +270,7 @@ else:
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = json.loads(%(html_theme_options)s)
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -307,13 +308,14 @@ html_static_path = ['_static']
 # 'odsa_root_path' specifies the relative path from the HTML output directory to the ODSA root directory and is used
 # to properly link to Privacy.html
 # The code that appends these scripts can be found in RST/_themes/haiku/layout.html and basic/layout.html
+
 html_context = {"script_files": [
                   #'https://code.jquery.com/jquery-2.1.4.min.js',
                   '%(eb2root)slib/jquery.min.js',
                   '%(eb2root)slib/jquery.migrate.min.js',
                   '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML',
                   '//cdnjs.cloudflare.com/ajax/libs/localforage/1.9.0/localforage.min.js',
-                  '%(eb2root)slib/accessibility.js',
+                  '%(eb2root)slib/accessibility.js' %(html_js_files)s
                 ],
                 "search_scripts": [
                   '_static/underscore.js',
@@ -341,7 +343,7 @@ html_context = {"script_files": [
                   '%(eb2root)slib/jquery.ui.min.css',
                   #'https://code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css',
                   '%(eb2root)slib/odsaStyle-min.css',
-                  '%(eb2root)slib/accessibility.css'
+                  '%(eb2root)slib/accessibility.css' %(html_css_files)s                  
                 ],
                 "odsa_root_path": "%(eb2root)s",
                 %(text_translated)s}
@@ -350,6 +352,8 @@ if on_slides:
    html_context["css_files"].append('%(eb2root)slib/ODSAcoursenotes.css');
    html_context["odsa_scripts"].append('%(eb2root)slib/ODSAcoursenotes.js');
 
+if '%(theme)s' != 'haiku':
+  html_context['script_files'] += html_context['odsa_scripts']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -347,6 +347,15 @@ def initialize_conf_py_options(config, slides):
     options['book_name'] = config.book_name
     options['theme_dir'] = config.theme_dir
     options['theme'] = config.theme
+    options['html_theme_options'] = "'{}'"
+    if config.html_theme_options:
+      options['html_theme_options'] = "'" + json.dumps(config.html_theme_options).replace("'", "\\'") + "'"
+    options['html_css_files'] = ""
+    if config.html_css_files:
+      options['html_css_files'] = ", '" + "', '".join(config.html_css_files) + "'"
+    options['html_js_files'] = ""
+    if config.html_js_files:
+      options['html_js_files'] = ", '" + "', '".join(config.html_js_files) + "'"
     options['odsa_dir'] = config.odsa_dir
     options['book_dir'] = config.book_dir
     options['code_dir'] = config.code_dir


### PR DESCRIPTION
These are the changes needed to support a custom sphinx theme (not supporting slides) for a book. To use a custom theme, one needs to run pip install to install the custom theme in the docker image.

See the config/Test.json file as an example, which uses the sphinx_book_theme instead of haiku (needs "pip install sphinx_book_theme" in the docker image). It also shows how support for custom theme parameters can be used (see its "html_theme_options" nested hash and "html_css_files" nested list, which refers to a custom css file located in RST/_static in this example).