### PR TITLE
Fix bug in hashInsert function

### DIFF
--- a/SourceCode/C++/Hashing/Hash.cpp
+++ b/SourceCode/C++/Hashing/Hash.cpp
@@ -39,11 +39,11 @@ int sfold(String s, int M) {
      int home;                     // Home position for e
      int pos = home = h(k);        // Init probe sequence
      for (int i=1; EMPTYKEY != (HT[pos]).key(); i++) {
-       pos = (home + p(k, i)) % M; // probe
        if (k == HT[pos].key()) {
          println("Duplicates not allowed");
          return;
        }
+       pos = (home + p(k, i)) % M; // probe
      }
      HT[pos] = e;
    }


### PR DESCRIPTION
Check for duplicate keys in hashInsert function should be before updating the position, if this check is done after updating the position then there is a case when there is a record with same key as the passed key in the home position , that is the key is already used in its home position, doing the check after updating using prope function will prevent the code to check if the key is already exists in its home position. The solution to this is to check before updating the position so key at the home position will be checked.