### PR TITLE
Fix json data in python insertion sort examples

### DIFF
--- a/AV/Sorting/InsertionSortAverageCaseCON.json
+++ b/AV/Sorting/InsertionSortAverageCaseCON.json
@@ -12,6 +12,18 @@
     }
   },
   "code": {
+    "python": [{
+      "url": "../../../SourceCode/Python/Sorting/Insertionsort.py",
+      "startAfter": "/* *** ODSATag: Insertionsort *** */",
+      "endBefore": "/* *** ODSAendTag: Insertionsort *** */",
+      "tags": {
+        "sig": 1,
+        "outloop": 2,
+        "inloop": 4,
+        "swap": 5,
+        "end": 6
+      }
+    }],
     "c++": [{
       "url": "../../../SourceCode/C++/Sorting/Insertionsort.cpp",
       "lineNumbers": false,

--- a/AV/Sorting/InsertionSortBestCaseCON.json
+++ b/AV/Sorting/InsertionSortBestCaseCON.json
@@ -9,6 +9,18 @@
     }
   },
   "code": {
+    "python": [{
+      "url": "../../../SourceCode/Python/Sorting/Insertionsort.py",
+      "startAfter": "/* *** ODSATag: Insertionsort *** */",
+      "endBefore": "/* *** ODSAendTag: Insertionsort *** */",
+      "tags": {
+        "sig": 1,
+        "outloop": 2,
+        "inloop": 4,
+        "swap": 5,
+        "end": 6
+      }
+    }],
     "c++": [{
       "url": "../../../SourceCode/C++/Sorting/Insertionsort.cpp",
       "lineNumbers": false,

--- a/AV/Sorting/InsertionSortWorstCaseCON.json
+++ b/AV/Sorting/InsertionSortWorstCaseCON.json
@@ -19,8 +19,8 @@
     }
   },
   "code": {
-    "Python": {
-      "url": "../../SourceCode/Python/Sorting/Insertionsort.py",
+    "python": [{
+      "url": "../../../SourceCode/Python/Sorting/Insertionsort.py",
       "startAfter": "/* *** ODSATag: Insertionsort *** */",
       "endBefore": "/* *** ODSAendTag: Insertionsort *** */",
       "tags": {
@@ -30,7 +30,7 @@
         "swap": 5,
         "end": 6
       }
-    },
+    }],
     "c++": [{
       "url": "../../../SourceCode/C++/Sorting/Insertionsort.cpp",
       "lineNumbers": false,


### PR DESCRIPTION
- Found malformed json data in AV/Sorting/InsertionSortWorstCaseCON.json.
- Extended python support to the rest of the examples in AV/Sorting/InsertionSortAverageCaseCON.json, and AV/Sorting/InsertionSortBestCaseCON.json.