### PR TITLE
CSS override so table paragraphs are left-justified

### DIFF
--- a/RST/_themes/haiku/static/haiku.css_t
+++ b/RST/_themes/haiku/static/haiku.css_t
@@ -288,6 +288,9 @@ h4 {
 p {
     text-align: justify;
 }
+table p {
+    text-align: left;
+}
 
 p.last {
     margin-bottom: 0;


### PR DESCRIPTION
Tiny CSS change to make paragraphs inside tables using the haiku theme to use normal left-justification. The haiku theme sets all paragraphs to use full justification, which looks fine in regular text but often looks weird (or sometimes less readable) in tables where column widths can be restricted.