### PR TITLE
Fix for scrolling problem in CodeWorkout iframes

### DIFF
--- a/RST/ODSAextensions/odsa/extrtoolembed/extrtoolembed.py
+++ b/RST/ODSAextensions/odsa/extrtoolembed/extrtoolembed.py
@@ -17,6 +17,7 @@ __author__ = 'hshahin'
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
+from pprint import pp
 import random
 import os, sys
 import urllib.request, urllib.parse, urllib.error
@@ -100,10 +101,12 @@ class extrtoolembed(Directive):
     """ Restructured text extension for inserting embedded external learning tools """
     if 'long_name' not in self.options or self.options['long_name'] == '' :
         print('ERROR: External learning tool is not properly configured -- missing long_name option')
+        pp(vars(self), indent = 2, compact = False)
         sys.exit()
 
     if 'learning_tool' not in self.options or self.options['learning_tool'] =='' :
         print('ERROR: External learning tool is not properly configured missing learning_tool option')
+        pp(vars(self), indent = 2, compact = False)
         sys.exit()
     
     # if 'workout_id' not in self.options or self.options['workout_id'] =='' :

--- a/RST/ODSAextensions/odsa/extrtoolembed/extrtoolembed.py
+++ b/RST/ODSAextensions/odsa/extrtoolembed/extrtoolembed.py
@@ -29,31 +29,31 @@ external_tools_urls = {
           "url": "https://codeworkout.cs.vt.edu/gym/workouts/embed",
           "frame_width": 1000,
           "frame_height": 900,
-          "enable_scrolling": "no"
+          "enable_scrolling": False
     },
     "code-workout-jhavepop": {
           "url": "https://codeworkout.cs.vt.edu/gym/workouts/embed",
           "frame_width": 1000,
           "frame_height": 900,
-          "enable_scrolling": "no"
+          "enable_scrolling": False
     },
     "mastery-grid-jsparsons-python": {
           "url": "https://pitt-acos.herokuapp.com/html/jsparsons/jsparsons-python/",
           "frame_width": 1000,
           "frame_height": 900,
-          "enable_scrolling": "no"
+          "enable_scrolling": False
     },
     "mastery-grid-java-animations": {
           "url": "https://pitt-acos.herokuapp.com/html/jsvee/jsvee-java/",
           "frame_width": 1000,
           "frame_height": 900,
-          "enable_scrolling": "no"
+          "enable_scrolling": False
     },
     "mastery-grid-python-animations": {
           "url": "https://pitt-acos.herokuapp.com/html/jsvee/jsvee-python/",
           "frame_width": 1000,
           "frame_height": 900,
-          "enable_scrolling": "no"
+          "enable_scrolling": False
     }
 }
 
@@ -138,6 +138,13 @@ class extrtoolembed(Directive):
       self.options['frame_height'] = external_tool['frame_height']
     if 'enable_scrolling' not in self.options:
       self.options['enable_scrolling'] = external_tool['enable_scrolling']
+
+    es = self.options['enable_scrolling']
+    if es in ["yes", "Yes", "true", "True", "on", "On", "auto", 1, True]:
+      es = "yes"
+    else:
+      es = "no"
+    self.options['enable_scrolling'] = es
 
     if 'launch_url' in self.options:
       self.options['tool_address'] = self.options['launch_url']

--- a/RST/ODSAextensions/odsa/extrtoolembed/extrtoolembed.py
+++ b/RST/ODSAextensions/odsa/extrtoolembed/extrtoolembed.py
@@ -27,32 +27,32 @@ import urllib.request, urllib.parse, urllib.error
 external_tools_urls = {
   "code-workout": {
           "url": "https://codeworkout.cs.vt.edu/gym/workouts/embed",
-          "width": 1000,
-          "height": 900,
+          "frame_width": 1000,
+          "frame_height": 900,
           "enable_scrolling": "no"
     },
     "code-workout-jhavepop": {
           "url": "https://codeworkout.cs.vt.edu/gym/workouts/embed",
-          "width": 1000,
-          "height": 900,
+          "frame_width": 1000,
+          "frame_height": 900,
           "enable_scrolling": "no"
     },
     "mastery-grid-jsparsons-python": {
           "url": "https://pitt-acos.herokuapp.com/html/jsparsons/jsparsons-python/",
-          "width": 1000,
-          "height": 900,
+          "frame_width": 1000,
+          "frame_height": 900,
           "enable_scrolling": "no"
     },
     "mastery-grid-java-animations": {
           "url": "https://pitt-acos.herokuapp.com/html/jsvee/jsvee-java/",
-          "width": 1000,
-          "height": 900,
+          "frame_width": 1000,
+          "frame_height": 900,
           "enable_scrolling": "no"
     },
     "mastery-grid-python-animations": {
           "url": "https://pitt-acos.herokuapp.com/html/jsvee/jsvee-python/",
-          "width": 1000,
-          "height": 900,
+          "frame_width": 1000,
+          "frame_height": 900,
           "enable_scrolling": "no"
     }
 }
@@ -72,8 +72,8 @@ CONTAINER_HTML= '''\
     data-long-name="%(long_name)s"
     data-short-name="%(short_name)s"
     data-frame-src="%(tool_address)s"
-    data-frame-width="%(width)s"
-    data-frame-height="%(height)s"
+    data-frame-width="%(frame_width)s"
+    data-frame-height="%(frame_height)s"
     data-type="%(type)s"
     data-workout-id="%(workout_id)s"
     data-enable-scrolling="%(enable_scrolling)s"
@@ -102,8 +102,8 @@ class extrtoolembed(Directive):
                  'id': directives.unchanged,
                  'workout_id': directives.unchanged,
                  'enable_scrolling': directives.unchanged,
-                 'width': directives.unchanged,
-                 'height': directives.unchanged
+                 'frame_width': directives.unchanged,
+                 'frame_height': directives.unchanged
                  }
 
   def run(self):
@@ -132,10 +132,10 @@ class extrtoolembed(Directive):
       self.options['workout_id'] = 0
 
     external_tool = external_tools_urls[self.options['learning_tool']]
-    if 'width' not in self.options:
-      self.options['width'] = external_tool['width']
-    if 'height' not in self.options:
-      self.options['height'] = external_tool['height']
+    if 'frame_width' not in self.options:
+      self.options['frame_width'] = external_tool['frame_width']
+    if 'frame_height' not in self.options:
+      self.options['frame_height'] = external_tool['frame_height']
     if 'enable_scrolling' not in self.options:
       self.options['enable_scrolling'] = external_tool['enable_scrolling']
 

--- a/RST/ODSAextensions/odsa/extrtoolembed/extrtoolembed.py
+++ b/RST/ODSAextensions/odsa/extrtoolembed/extrtoolembed.py
@@ -28,27 +28,32 @@ external_tools_urls = {
   "code-workout": {
           "url": "https://codeworkout.cs.vt.edu/gym/workouts/embed",
           "width": 1000,
-          "height": 900
+          "height": 900,
+          "enable_scrolling": "no"
     },
     "code-workout-jhavepop": {
           "url": "https://codeworkout.cs.vt.edu/gym/workouts/embed",
           "width": 1000,
-          "height": 900
+          "height": 900,
+          "enable_scrolling": "no"
     },
     "mastery-grid-jsparsons-python": {
           "url": "https://pitt-acos.herokuapp.com/html/jsparsons/jsparsons-python/",
           "width": 1000,
-          "height": 900
+          "height": 900,
+          "enable_scrolling": "no"
     },
     "mastery-grid-java-animations": {
           "url": "https://pitt-acos.herokuapp.com/html/jsvee/jsvee-java/",
           "width": 1000,
-          "height": 900
+          "height": 900,
+          "enable_scrolling": "no"
     },
     "mastery-grid-python-animations": {
           "url": "https://pitt-acos.herokuapp.com/html/jsvee/jsvee-python/",
           "width": 1000,
-          "height": 900
+          "height": 900,
+          "enable_scrolling": "no"
     }
 }
 
@@ -71,6 +76,7 @@ CONTAINER_HTML= '''\
     data-frame-height="%(height)s"
     data-type="%(type)s"
     data-workout-id="%(workout_id)s"
+    data-enable-scrolling="%(enable_scrolling)s"
     data-exer-id="%(id)s">
   %(content)s
   <div class="center">
@@ -84,8 +90,8 @@ def print_err(*args, **kwargs):
   print(*args, file=sys.stderr, **kwargs)
 
 class extrtoolembed(Directive):
-  required_arguments = 0
-  optional_arguments = 4
+  required_arguments = 1
+  optional_arguments = 0
   final_argument_whitespace = True
   has_content = True
   option_spec = {
@@ -94,7 +100,10 @@ class extrtoolembed(Directive):
                  'learning_tool': directives.unchanged,
                  'launch_url': directives.unchanged,
                  'id': directives.unchanged,
-                 'workout_id': directives.unchanged
+                 'workout_id': directives.unchanged,
+                 'enable_scrolling': directives.unchanged,
+                 'width': directives.unchanged,
+                 'height': directives.unchanged
                  }
 
   def run(self):
@@ -123,8 +132,12 @@ class extrtoolembed(Directive):
       self.options['workout_id'] = 0
 
     external_tool = external_tools_urls[self.options['learning_tool']]
-    self.options['width'] = external_tool['width']
-    self.options['height'] = external_tool['height']
+    if 'width' not in self.options:
+      self.options['width'] = external_tool['width']
+    if 'height' not in self.options:
+      self.options['height'] = external_tool['height']
+    if 'enable_scrolling' not in self.options:
+      self.options['enable_scrolling'] = external_tool['enable_scrolling']
 
     if 'launch_url' in self.options:
       self.options['tool_address'] = self.options['launch_url']

--- a/lib/odsaMOD.css
+++ b/lib/odsaMOD.css
@@ -164,6 +164,8 @@ iframe {
   overflow: hidden;
 }
 
+iframe.enable-scrolling { overflow: auto; }
+
 .embeddedExercise {
   /* Set the position and top attributes to prevent the page from */
   /* automatically scrolling to iframes as they load */

--- a/lib/odsaMOD.js
+++ b/lib/odsaMOD.js
@@ -1389,9 +1389,11 @@
         separator = $elem.attr("data-frame-src").includes("?") ? "&" : "?",
         shortName = $elem.attr("data-short-name"),
         exerId = $elem.attr("data-exer-id"),
+        enableScrolling = $elem.attr("data-enable-scrolling"),
         src = $elem.attr("data-frame-src") + separator + 'scoringServerEnabled=' + odsaUtils.scoringServerEnabled() + '&loggingServerEnabled=' + odsaUtils.loggingServerEnabled() + '&threshold=' + threshold + '&points=' + points + '&required=' + required;
         workoutId = $elem.attr("data-workout-id")
 
+      if (enableScrolling == null) { enableScrolling = "no"; }
       if (workoutId) {
         src = src + '&workoutId=' + workoutId
       }
@@ -1421,7 +1423,9 @@
       }
 
       // Dynamic iFrame loading method based on: http://geekoutwith.me/2010/10/make-iframes-load-after-page-content-with-jquery/
-      $(iFrameSelector).replaceWith('<iframe id="' + exerName + '_iframe" aria-label="exercise" src="' + src + '" class="embeddedExercise" width="' + width + '" height="' + height + '" data-showhide="' + showhide + '" scrolling="no" >Your browser does not support iframes.</iframe>');
+      var cssCls = "embeddedExercise";
+      if (enableScrolling == "yes") { cssCls += " enable-scrolling"; }
+      $(iFrameSelector).replaceWith('<iframe id="' + exerName + '_iframe" aria-label="exercise" src="' + src + '" class="' + cssCls + '" width="' + width + '" height="' + height + '" data-showhide="' + showhide + '" scrolling="'+ enableScrolling + '" >Your browser does not support iframes.</iframe>');
 
       // if(vscroll === "yes") $(iFrameSelector).css("overflow-y","scroll")
       // else $(iFrameSelector).attr('scrolling',"no")

--- a/tools/ODSA_Config.py
+++ b/tools/ODSA_Config.py
@@ -370,6 +370,12 @@ def group_exercises(conf_data, no_lms):
                           exercise_obj['long_name'] = section_obj['long_name']
                         else:
                           exercise_obj['long_name'] = section
+                        if 'enable_scrolling' in section_obj:
+                          exercise_obj['enable_scrolling'] = section_obj['enable_scrolling']
+                        if 'width' in section_obj:
+                          exercise_obj['width'] = section_obj['width']
+                        if 'height' in section_obj:
+                          exercise_obj['height'] = section_obj['height']
                         exercise_obj['learning_tool'] = section_obj['learning_tool']
                         if 'launch_url' in section_obj:
                             exercise_obj['launch_url'] = section_obj['launch_url']

--- a/tools/ODSA_Config.py
+++ b/tools/ODSA_Config.py
@@ -366,12 +366,15 @@ def group_exercises(conf_data, no_lms):
                               conf_data['chapters'][chapter][module]['exercises'][attr] = exercise_obj
                     if 'learning_tool' in list(section_obj.keys()):
                         exercise_obj = {}
-                        exercise_obj['long_name'] = section
+                        if 'long_name' in section_obj:
+                          exercise_obj['long_name'] = section_obj['long_name']
+                        else:
+                          exercise_obj['long_name'] = section
                         exercise_obj['learning_tool'] = section_obj['learning_tool']
                         if 'launch_url' in section_obj:
                             exercise_obj['launch_url'] = section_obj['launch_url']
                             exercise_obj['id'] = section_obj['id']
-                        conf_data['chapters'][chapter][module]['exercises'][section] = exercise_obj
+                        conf_data['chapters'][chapter][module]['exercises'][exercise_obj['long_name']] = exercise_obj
 
 def get_translated_text(lang_):
     """ Loads appropriate text from language_msg.json file based on book language  """

--- a/tools/ODSA_Config.py
+++ b/tools/ODSA_Config.py
@@ -372,10 +372,10 @@ def group_exercises(conf_data, no_lms):
                           exercise_obj['long_name'] = section
                         if 'enable_scrolling' in section_obj:
                           exercise_obj['enable_scrolling'] = section_obj['enable_scrolling']
-                        if 'width' in section_obj:
-                          exercise_obj['width'] = section_obj['width']
-                        if 'height' in section_obj:
-                          exercise_obj['height'] = section_obj['height']
+                        if 'frame_width' in section_obj:
+                          exercise_obj['frame_width'] = section_obj['frame_width']
+                        if 'frame_height' in section_obj:
+                          exercise_obj['frame_height'] = section_obj['frame_height']
                         exercise_obj['learning_tool'] = section_obj['learning_tool']
                         if 'launch_url' in section_obj:
                             exercise_obj['launch_url'] = section_obj['launch_url']

--- a/tools/ODSA_RST_Module.py
+++ b/tools/ODSA_RST_Module.py
@@ -752,7 +752,8 @@ class ODSA_RST_Module:
                             # Add the necessary information from the configuration file
                             exer_conf = exercises[external_tool_name]
                             # List of valid options for avembed directive
-                            options = ['long_name',
+                            options = ['long_name', 'enable_scrolling',
+                                       'width', 'height',
                                        'learning_tool', 'launch_url', 'id']
                             dir_opts = parse_directive_options(mod_data, i)
                             options = [

--- a/tools/ODSA_RST_Module.py
+++ b/tools/ODSA_RST_Module.py
@@ -753,7 +753,7 @@ class ODSA_RST_Module:
                             exer_conf = exercises[external_tool_name]
                             # List of valid options for avembed directive
                             options = ['long_name', 'enable_scrolling',
-                                       'width', 'height',
+                                       'frame_width', 'frame_height',
                                        'learning_tool', 'launch_url', 'id']
                             dir_opts = parse_directive_options(mod_data, i)
                             options = [

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -171,7 +171,7 @@ def process_module(config, index_rst, mod_path, mod_attrib={'exercises': {}}, de
     global module_chap_map
     global num_ref_map
     global cmap_map
-
+    
     # Parse the name of the module from mod_path and remove the file extension
     # if it exists
     mod_name = os.path.splitext(os.path.basename(mod_path))[0]

--- a/tools/simple2full.py
+++ b/tools/simple2full.py
@@ -191,7 +191,9 @@ class extrtoolembed(Directive):
                  }
 
   def run(self):
-    resource_name = self.arguments[0]
+    resource_name = self.arguments[0].strip()
+    # change any single-quotes to double-quotes for XML
+    resource_name = re.sub(r"'(.*)'", r'"\1"', resource_name)
     if 'resource_name' not in self.options or self.options['resource_name'] == '':
       self.options['resource_name'] = resource_name
     if 'workout_id' not in self.options or self.options['workout_id'] == '':
@@ -700,6 +702,7 @@ def extract_exs_config(exs_json):
       exs_config['extertool']['learning_tool'] = ex_obj['@learning_tool']
       exs_config['extertool']['resource_type'] = ex_obj['@resource_type']
       exs_config['extertool']['resource_name'] = ex_obj['@resource_name']
+      exs_config['extertool']['long_name'] = ex_obj['@resource_name']
       exs_config['extertool']['points'] = float(ex_obj['@points'])
       exs_config['extertool']['workout_id'] = ex_obj['@workout_id']
       if expanded:

--- a/tools/simple2full.py
+++ b/tools/simple2full.py
@@ -57,6 +57,9 @@ _default_ex_options = {
       'threshold': 1
     },
     'extr': {
+      'enable_scrolling' : 'no',
+      'width': 1000,
+      'height': 900,
       'points': 1.0
     }
 }
@@ -94,6 +97,9 @@ extertool_element = '''\
     resource_type="%(resource_type)s"
     learning_tool="%(learning_tool)s"
     points="%(points)s"
+    enable_scrolling="%(enable_scrolling)s"
+    width="%(width)s"
+    height="%(height)s"
     mod_name="%(mod_name)s">
 </extertool>
 '''
@@ -187,7 +193,10 @@ class extrtoolembed(Directive):
                  'workout_id': directives.unchanged,
                  'resource_type': directives.unchanged,
                  'learning_tool': directives.unchanged,
-                 'points': directives.unchanged
+                 'enable_scrolling': directives.unchanged,
+                 'points': directives.unchanged,
+                 'width': directives.unchanged,
+                 'height': directives.unchanged
                  }
 
   def run(self):
@@ -204,6 +213,12 @@ class extrtoolembed(Directive):
       self.options['learning_tool'] = 'code-workout'
     if 'points' not in self.options or self.options['points'] == '':
       self.options['points'] = get_default_ex_option('extr', 'points', self.options['learning_tool'])
+    if 'enable_scrolling' not in self.options or self.options['enable_scrolling'] == '':
+      self.options['enable_scrolling'] = get_default_ex_option('extr', 'enable_scrolling', self.options['learning_tool'])
+    if 'width' not in self.options or self.options['width'] == '':
+      self.options['width'] = get_default_ex_option('extr', 'width', self.options['learning_tool'])
+    if 'height' not in self.options or self.options['height'] == '':
+      self.options['height'] = get_default_ex_option('extr', 'height', self.options['learning_tool'])
 
     self.options['mod_name'] = current_module_base
     
@@ -485,17 +500,17 @@ def get_default_ex_option(ex_type, option, learning_tool=None):
     if 'extr' not in default_ex_options:
       print_err('WARNING: Missing "glob_extr_options", using default values instead.')
       default_ex_options['extr'] = _default_ex_options['extr']
-      return default_ex_options['extr']['points']
+      return default_ex_options['extr'][option]
     elif learning_tool in default_ex_options['extr']:
-      if 'points' in default_ex_options['extr'][learning_tool]:
-        return default_ex_options['extr'][learning_tool]['points']
-    if 'points' not in default_ex_options['extr']:
-      def_val = _default_ex_options['extr']['points']
-      print_err('WARNING: "glob_extr_options" is missing field "points". Using default value "{0}".'.format(def_val))
-      default_ex_options['extr']['points'] = def_val
+      if option in default_ex_options['extr'][learning_tool]:
+        return default_ex_options['extr'][learning_tool][option]
+    if option not in default_ex_options['extr']:
+      def_val = _default_ex_options['extr'][option]
+      print_err('WARNING: "glob_extr_options" is missing field "{0}". Using default value "{1}".'.format(option, def_val))
+      default_ex_options['extr'][option] = def_val
       return def_val
     else:
-      return default_ex_options['extr']['points']
+      return default_ex_options['extr'][option]
   elif ex_type == 'dgm':
     return _default_ex_options['dgm']
   else:
@@ -624,6 +639,10 @@ def extract_exs_config(exs_json):
         exs_config['extertool']['learning_tool'] = ex_obj['@learning_tool']
         exs_config['extertool']['resource_type'] = ex_obj['@resource_type']
         exs_config['extertool']['resource_name'] = ex_obj['@resource_name']
+        exs_config['extertool']['long_name'] = ex_obj['@resource_name']
+        exs_config['extertool']['enable_scrolling'] = ex_obj['@enable_scrolling']
+        exs_config['extertool']['width'] = ex_obj['@width']
+        exs_config['extertool']['height'] = ex_obj['@height']
         exs_config['extertool']['points'] = float(ex_obj['@points'])
         if expanded:
           exs_config['extertool']['type'] = 'extr'
@@ -703,6 +722,9 @@ def extract_exs_config(exs_json):
       exs_config['extertool']['resource_type'] = ex_obj['@resource_type']
       exs_config['extertool']['resource_name'] = ex_obj['@resource_name']
       exs_config['extertool']['long_name'] = ex_obj['@resource_name']
+      exs_config['extertool']['enable_scrolling'] = ex_obj['@enable_scrolling']
+      exs_config['extertool']['width'] = ex_obj['@width']
+      exs_config['extertool']['height'] = ex_obj['@height']
       exs_config['extertool']['points'] = float(ex_obj['@points'])
       exs_config['extertool']['workout_id'] = ex_obj['@workout_id']
       if expanded:

--- a/tools/simple2full.py
+++ b/tools/simple2full.py
@@ -58,8 +58,8 @@ _default_ex_options = {
     },
     'extr': {
       'enable_scrolling' : 'no',
-      'width': 1000,
-      'height': 900,
+      'frame_width': 1000,
+      'frame_height': 900,
       'points': 1.0
     }
 }
@@ -98,8 +98,8 @@ extertool_element = '''\
     learning_tool="%(learning_tool)s"
     points="%(points)s"
     enable_scrolling="%(enable_scrolling)s"
-    width="%(width)s"
-    height="%(height)s"
+    frame_width="%(frame_width)s"
+    frame_height="%(frame_height)s"
     mod_name="%(mod_name)s">
 </extertool>
 '''
@@ -195,8 +195,8 @@ class extrtoolembed(Directive):
                  'learning_tool': directives.unchanged,
                  'enable_scrolling': directives.unchanged,
                  'points': directives.unchanged,
-                 'width': directives.unchanged,
-                 'height': directives.unchanged
+                 'frame_width': directives.unchanged,
+                 'frame_height': directives.unchanged
                  }
 
   def run(self):
@@ -215,10 +215,10 @@ class extrtoolembed(Directive):
       self.options['points'] = get_default_ex_option('extr', 'points', self.options['learning_tool'])
     if 'enable_scrolling' not in self.options or self.options['enable_scrolling'] == '':
       self.options['enable_scrolling'] = get_default_ex_option('extr', 'enable_scrolling', self.options['learning_tool'])
-    if 'width' not in self.options or self.options['width'] == '':
-      self.options['width'] = get_default_ex_option('extr', 'width', self.options['learning_tool'])
-    if 'height' not in self.options or self.options['height'] == '':
-      self.options['height'] = get_default_ex_option('extr', 'height', self.options['learning_tool'])
+    if 'frame_width' not in self.options or self.options['frame_width'] == '':
+      self.options['frame_width'] = get_default_ex_option('extr', 'frame_width', self.options['learning_tool'])
+    if 'frame_height' not in self.options or self.options['frame_height'] == '':
+      self.options['frame_height'] = get_default_ex_option('extr', 'frame_height', self.options['learning_tool'])
 
     self.options['mod_name'] = current_module_base
     
@@ -641,8 +641,8 @@ def extract_exs_config(exs_json):
         exs_config['extertool']['resource_name'] = ex_obj['@resource_name']
         exs_config['extertool']['long_name'] = ex_obj['@resource_name']
         exs_config['extertool']['enable_scrolling'] = ex_obj['@enable_scrolling']
-        exs_config['extertool']['width'] = ex_obj['@width']
-        exs_config['extertool']['height'] = ex_obj['@height']
+        exs_config['extertool']['frame_width'] = ex_obj['@frame_width']
+        exs_config['extertool']['frame_height'] = ex_obj['@frame_height']
         exs_config['extertool']['points'] = float(ex_obj['@points'])
         if expanded:
           exs_config['extertool']['type'] = 'extr'
@@ -723,8 +723,8 @@ def extract_exs_config(exs_json):
       exs_config['extertool']['resource_name'] = ex_obj['@resource_name']
       exs_config['extertool']['long_name'] = ex_obj['@resource_name']
       exs_config['extertool']['enable_scrolling'] = ex_obj['@enable_scrolling']
-      exs_config['extertool']['width'] = ex_obj['@width']
-      exs_config['extertool']['height'] = ex_obj['@height']
+      exs_config['extertool']['frame_width'] = ex_obj['@frame_width']
+      exs_config['extertool']['frame_height'] = ex_obj['@frame_height']
       exs_config['extertool']['points'] = float(ex_obj['@points'])
       exs_config['extertool']['workout_id'] = ex_obj['@workout_id']
       if expanded:

--- a/tools/simple2full.py
+++ b/tools/simple2full.py
@@ -57,7 +57,7 @@ _default_ex_options = {
       'threshold': 1
     },
     'extr': {
-      'enable_scrolling' : 'no',
+      'enable_scrolling' : False,
       'frame_width': 1000,
       'frame_height': 900,
       'points': 1.0


### PR DESCRIPTION
This fix includes four pieces:

- Support for a custom CSS class on iframes of external tool embeds indicating whether scrolling is enabled, together with a CSS rule override so that when that class is active, an iframe has "overflow: auto" instead of "overflow: hidden".
- Support for an "enable_scrolling" option that can be used in an external tool's global options in the JSON config, in a specific exercise's options within the JSON config, or directly as an option on an extrtoolembed directive in the RST. If set to "yes", it enables scrolling of the iframe contents. The default is "no".
- Support for "width" and "height" options being explicitly included in an external tool's global options in the JSON config, in a specific exercise's options within the JSON config, or directly as an option on an extrtoolembed directive.
- Decoupling of RST document section names from the exercise long_name in an extrtoolembed, so that parameters and settings use the extrtoolembed argument rather than the text document's section name. This prevents failures when the extrtoolembed argument is different than the title of the section where it appears.

These fixes are all localized to this repo and do not affect the OpenDSA-LTI repo. They are all presentation issues when compiling a book, and have no effect on the book instance data model or any of its relatives in the rails application.