### PR TITLE
Updated broken URL for BST java class file

### DIFF
--- a/RST/en/Tutorials/junitbasic.rst
+++ b/RST/en/Tutorials/junitbasic.rst
@@ -29,7 +29,7 @@ Before you start, be sure you have familiarized yourself with the basics of the
 .. |external_link| raw:: html
 
    <a
-   href="https://www.cs.cmu.edu/~adamchik/15-121/lectures/Trees/code/BST.java" target = "_blank">Here is the full BST source code</a>
+   href="https://viterbi-web.usc.edu/~adamchik/15-121/lectures/Trees/code/BST.java" target = "_blank">Here is the full BST source code</a>
 
 
 While this class contains many methods this tutorial will only be testing a few.


### PR DESCRIPTION
Looks like Prof. Adamchik has moved from CMU to USC. Updated URL to reflect such.

closes #460 