### PR TITLE
including keyword as custom directive to avmetadata class 

### DIFF
--- a/RST/ODSAextensions/odsa/avmetadata/avmetadata.py
+++ b/RST/ODSAextensions/odsa/avmetadata/avmetadata.py
@@ -46,6 +46,7 @@ class avmetadata(Directive):
                    'topic': directives.unchanged,
                    'requires': directives.unchanged,
                    'satisfies': directives.unchanged,
+                   'keyword': directives.unchanged, #keyword directive added 
                    #'short_name': directives.unchanged,
                    #'exercises': directives.unchanged,    
                    }
@@ -70,7 +71,8 @@ This is some text.
    :author:
    :topic:
    :requires:
-   :satisfies:   
+   :satisfies: 
+   :keyword:  
 
 This is some more text.
 """

--- a/RST/en/Sorting/BinSort.rst
+++ b/RST/en/Sorting/BinSort.rst
@@ -8,6 +8,7 @@
    :requires: sorting terminology
    :satisfies: binsort
    :topic: Sorting
+   :keyword: Bucket Sort, Sorting, Recursion
 
 .. index:: ! Binsort
 

--- a/tools/ODSA_RST_Module.py
+++ b/tools/ODSA_RST_Module.py
@@ -376,7 +376,12 @@ class ODSA_RST_Module:
             if os.environ.get('SLIDES', None) == "yes":
                 # implicit hyperlink from '.. _%(mod_name)s:' creates a critical error when building slides
                 config_templates.rst_header = config_templates.rst_header.replace('.. _%(mod_name)s:', '.. LINK REMOVED for slides')
-            mod_data.insert(0, config_templates.rst_header % header_data)
+            # mod_data.insert(0, config_templates.rst_header % header_data)
+            # fixes for "Error: content expected after raw directive" when compiling a book, formats rst header data in book/'compiled-book'/source
+            formatted_header = config_templates.rst_header % header_data
+            formatted_header = formatted_header.replace(".. raw:: html", ".. raw:: html\n\n   ")
+            mod_data.insert(0, formatted_header)
+
 
             avmetadata_found = False
 

--- a/tools/config_templates.py
+++ b/tools/config_templates.py
@@ -13,6 +13,7 @@ rst_header = '''\
 
 rst_footer = '''\
  .. raw:: html
+ 
     <script type="text/javascript">
      $(function () {
        var moduleName = "%(module_name)s";

--- a/tools/rst2json.py
+++ b/tools/rst2json.py
@@ -139,7 +139,8 @@ class avmetadata(Directive):
                  'topic': directives.unchanged,
                  'requires': directives.unchanged,
                  'satisfies': directives.unchanged,
-                 'prerequisites': directives.unchanged
+                 'prerequisites': directives.unchanged,
+                 'keyword': directives.unchanged #keyword directive added for SPLICE catalog  
                  }
 
   def run(self):


### PR DESCRIPTION
- Including 'keyword' as custom directive to avmetadata class for Splice Catalog in opendsa/RST/odsaextensions/odsa/avmetadata
- Fixes for 'Error: content expected after raw directive' when compiling books. formatting update is included in opendsa/tools/odsa_RST_Module and opendsa/tools/conffig_templates