### PR TITLE
Removed shortcut links

### DIFF
--- a/RST/en/MengBridgeCourse/2114Bags1.rst
+++ b/RST/en/MengBridgeCourse/2114Bags1.rst
@@ -9,16 +9,6 @@
 Bags
 ====
 
-Shortcuts
----------
-
-- :ref:`BagBasics`
-- :ref:`BagUsage`
-- :ref:`BagArrayImp`
-- :ref:`BagArrayMethods`
-- :ref:`BagArrayMethods2`
-- :ref:`BagArrayMethods3`
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114Bags2.rst
+++ b/RST/en/MengBridgeCourse/2114Bags2.rst
@@ -9,15 +9,6 @@
 Linked Bags
 ===========
 
-Shortcuts
----------
-
-- :ref:`LinkedBagIntro`
-- :ref:`LinkedBagAdd`
-- :ref:`LinkedBagTest`
-- :ref:`LinkedBagContains`
-- :ref:`LinkedBagRemove`
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114ComparingAndSorting.rst
+++ b/RST/en/MengBridgeCourse/2114ComparingAndSorting.rst
@@ -9,15 +9,6 @@
 Comparing and Sorting
 =====================
 
-Shortcuts
----------
-
-- :ref:`SortOrderIntro`
-- :ref:`SortIntro`
-- :ref:`SortSelect`
-- :ref:`SortInsert`
-- :ref:`SortCompareIntro`
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114Exceptions.rst
+++ b/RST/en/MengBridgeCourse/2114Exceptions.rst
@@ -9,17 +9,6 @@
 More on Exceptions
 ==================
 
-Shortcuts
----------
-
-- :ref:`ExceptionHandling`
-- :ref:`ExceptionCheckedUnchecked`
-- :ref:`ExceptionTryCatch`
-- :ref:`ExceptionHandleLater`
-- :ref:`ExceptionExamples`
-- :ref:`ExceptionTesting`
-
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114Generics2.rst
+++ b/RST/en/MengBridgeCourse/2114Generics2.rst
@@ -9,14 +9,6 @@
 More on Generics
 ================
 
-Shortcuts
----------
-
-- :ref:`Generics2Intro`
-- :ref:`Generics2Reflect`
-- :ref:`Generics2Explained`
-- :ref:`Generics2Wildcard`
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114Iterators.rst
+++ b/RST/en/MengBridgeCourse/2114Iterators.rst
@@ -9,16 +9,6 @@
 Iterators
 =========
 
-Shortcuts
----------
-
-- :ref:`IteratorIntro`
-- :ref:`IteratorInterface`
-- :ref:`IteratorProg`
-- :ref:`IteratorDesign`
-- :ref:`IteratorInner`
-
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114LinkedChainPointers.rst
+++ b/RST/en/MengBridgeCourse/2114LinkedChainPointers.rst
@@ -9,13 +9,6 @@
 Linked Chains (Pointers)
 ========================
 
-Shortcuts
----------
-
-- :ref:`PointerLinkedNodes`
-- :ref:`PointerVisDemo`
-- :ref:`PointerContains`
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114Lists.rst
+++ b/RST/en/MengBridgeCourse/2114Lists.rst
@@ -9,15 +9,6 @@
 Lists
 =====
 
-Shortcuts
----------
-
-- :ref:`ListIntro`
-- :ref:`ListAdd`
-- :ref:`ListRemove`
-- :ref:`ListOptions`
-- :ref:`ListArray`
-
 Overview & Objectives
 ---------------------
 

--- a/RST/en/MengBridgeCourse/2114Queues.rst
+++ b/RST/en/MengBridgeCourse/2114Queues.rst
@@ -9,15 +9,6 @@
 Queues
 ======
 
-Shortcuts
----------
-
-- :ref:`QueueIntro`
-- :ref:`QueueLinked`
-- :ref:`QueueIntroDeque`
-- :ref:`QueueArray`
-
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114Recursion.rst
+++ b/RST/en/MengBridgeCourse/2114Recursion.rst
@@ -10,15 +10,6 @@
 Recursion
 =========
 
-Shortcuts
----------
-
-- :ref:`RecursionIntro`
-- :ref:`RecursionExample`
-- :ref:`RecursionArray`
-- :ref:`RecursionChain`
-- :ref:`RecursionConclusion`
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114SoftwareDesignAndMVC.rst
+++ b/RST/en/MengBridgeCourse/2114SoftwareDesignAndMVC.rst
@@ -9,19 +9,6 @@
 Software Design and MVC
 =======================
 
-Shortcuts
----------
-
-- :ref:`DesignIntro`
-- :ref:`DesignRequirements`
-- :ref:`DesignClasses`
-- :ref:`DesignActivity1`
-- :ref:`DesignRelations`
-- :ref:`DesignActivity2`
-- :ref:`DesignMVC`
-- :ref:`DesignCaseStudies`
-
-
 Objectives
 ----------
 

--- a/RST/en/MengBridgeCourse/2114Stacks.rst
+++ b/RST/en/MengBridgeCourse/2114Stacks.rst
@@ -9,16 +9,6 @@
 Stacks
 ======
 
-Shortcuts
----------
-
-- :ref:`StacksIntro`
-- :ref:`StacksMemory`
-- :ref:`StacksArrayBased`
-- :ref:`StacksArrayImpl`
-- :ref:`StacksChainImpl`
-
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentBags1.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentBags1.rst
@@ -9,16 +9,6 @@
 Bags
 ====
 
-Shortcuts
----------
-
-- :ref:`BagBasics`
-- :ref:`BagUsage`
-- :ref:`BagArrayImp`
-- :ref:`BagArrayMethods`
-- :ref:`BagArrayMethods2`
-- :ref:`BagArrayMethods3`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentBinarySearchTrees.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentBinarySearchTrees.rst
@@ -10,18 +10,6 @@
 Binary Search Trees
 ===================
 
-..
-    Shortcuts
-    ---------
-
-    - :ref:`BSTIntro`
-    - :ref:`BSTProg`
-    - :ref:`BSTAdd`
-    - :ref:`BSTRemove`
-    - :ref:`JavaScopeAndEquality`
-    - :ref:`JavaObjectsAndEnums`
-
-
 Objectives
 ----------
 * Distinguish a Binary Tree from a Binary Search Tree (BST)

--- a/RST/en/SWDesignAndDataStructs/ContentComparingAndSorting.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentComparingAndSorting.rst
@@ -9,16 +9,6 @@
 Comparing and Sorting
 =====================
 
-Shortcuts
----------
-
-- :ref:`SortOrderIntro`
-- :ref:`SortIntro`
-- :ref:`SortSelect`
-- :ref:`SortInsert`
-- :ref:`SortCompareIntro`
-
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentDesignMVC.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentDesignMVC.rst
@@ -9,19 +9,6 @@
 Software Design and MVC
 =======================
 
-Shortcuts
----------
-
-- :ref:`DesignIntro`
-- :ref:`DesignRequirements`
-- :ref:`DesignClasses`
-- :ref:`DesignActivity1`
-- :ref:`DesignRelations`
-- :ref:`DesignActivity2`
-- :ref:`DesignMVC`
-- :ref:`DesignCaseStudies`
-
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentEthics.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentEthics.rst
@@ -10,15 +10,6 @@
 Ethics
 ======
 
-..
-    Shortcuts
-    ---------
-    
-    - :ref:`EthicsIntro`
-    - :ref:`EthicsACM`
-    - :ref:`Ethics8KQ`
-    - :ref:`EthicsMoralMach`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentExceptions.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentExceptions.rst
@@ -9,17 +9,6 @@
 Exceptions
 ==========
 
-Shortcuts
----------
-
-- :ref:`ExceptionHandling`
-- :ref:`ExceptionCheckedUnchecked`
-- :ref:`ExceptionTryCatch`
-- :ref:`ExceptionHandleLater`
-- :ref:`ExceptionExamples`
-- :ref:`ExceptionTesting`
-
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentFundamentals.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentFundamentals.rst
@@ -10,17 +10,6 @@
 Java Fundamentals
 ================================
 
-..
-    Shortcuts
-    ---------
-    
-    - :ref:`JavaBasics`
-    - :ref:`JavaMethods`
-    - :ref:`JavaVariables`
-    - :ref:`JavaControlFlow`
-    - :ref:`JavaScopeAndEquality`
-    - :ref:`JavaObjectsAndEnums`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentGenerics2.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentGenerics2.rst
@@ -9,14 +9,6 @@
 More on Generics
 ================
 
-Shortcuts
----------
-
-- :ref:`Generics2Intro`
-- :ref:`Generics2Reflect`
-- :ref:`Generics2Explained`
-- :ref:`Generics2Wildcard`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentIterators.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentIterators.rst
@@ -9,16 +9,6 @@
 Iterators
 =========
 
-Shortcuts
----------
-
-- :ref:`IteratorIntro`
-- :ref:`IteratorInterface`
-- :ref:`IteratorProg`
-- :ref:`IteratorDesign`
-- :ref:`IteratorInner`
-- :ref:`IteratorScanner`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentJavaArrays.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentJavaArrays.rst
@@ -10,17 +10,6 @@
 Java Arrays
 ===========
 
-..
-    Shortcuts
-    ---------
-    
-    - :ref:`JavaArrayBasics`
-    - :ref:`JavaArraySearch`
-    - :ref:`JavaArrayMethods`
-
-
-
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentLinkedBags.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentLinkedBags.rst
@@ -9,15 +9,6 @@
 Linked Bags
 ===========
 
-Shortcuts
----------
-
-- :ref:`LinkedBagIntro`
-- :ref:`LinkedBagAdd`
-- :ref:`LinkedBagTest`
-- :ref:`LinkedBagContains`
-- :ref:`LinkedBagRemove`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentLinkedChains.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentLinkedChains.rst
@@ -10,14 +10,6 @@
 Linked Chains (Pointers)
 ========================
 
-Shortcuts
----------
-
-- :ref:`PointerReference`
-- :ref:`PointerLinkedNodes`
-- :ref:`PointerVisDemo`
-- :ref:`PointerContains`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentLists.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentLists.rst
@@ -9,15 +9,6 @@
 Lists
 =====
 
-Shortcuts
----------
-
-- :ref:`ListIntro`
-- :ref:`ListAdd`
-- :ref:`ListRemove`
-- :ref:`ListOptions`
-- :ref:`ListArray`
-
 Overview & Objectives
 ---------------------
 

--- a/RST/en/SWDesignAndDataStructs/ContentPolymorphism.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentPolymorphism.rst
@@ -10,17 +10,6 @@
 Polymorphism
 ============
 
-..
-    Shortcuts
-    ---------
-    
-    - :ref:`IntroOOP`
-    - :ref:`IntroUML`
-    - :ref:`IntroInheritance`
-    - :ref:`IntroPolyMeasure`
-    - :ref:`IntroPolySuper`
-    - :ref:`IntroPolyExample`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentQueues.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentQueues.rst
@@ -9,15 +9,6 @@
 Queues
 ======
 
-Shortcuts
----------
-
-- :ref:`QueueIntro`
-- :ref:`QueueLinked`
-- :ref:`QueueIntroDeque`
-- :ref:`QueueArray`
-
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentRecursion.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentRecursion.rst
@@ -10,15 +10,6 @@
 Recursion
 =========
 
-Shortcuts
----------
-
-- :ref:`RecursionIntro`
-- :ref:`RecursionExample`
-- :ref:`RecursionArray`
-- :ref:`RecursionChain`
-- :ref:`RecursionConclusion`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentSortedLists.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentSortedLists.rst
@@ -10,18 +10,6 @@
 Sorted Lists
 ============
 
-Shortcuts
----------
-
-- :ref:`SortListIntro`
-- :ref:`SortListADT`
-- :ref:`SortListInterface`
-- :ref:`SortListImp`
-- :ref:`SortListImpScratch`
-- :ref:`SortListImpComposition`
-- :ref:`SortListImpInheritance`
-
- 
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentStacks.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentStacks.rst
@@ -9,15 +9,6 @@
 Stacks
 ======
 
-Shortcuts
----------
-
-- :ref:`StacksIntro`
-- :ref:`StacksMemory`
-- :ref:`StacksArrayBased`
-- :ref:`StacksArrayImpl`
-- :ref:`StacksChainImpl`
-
 Objectives
 ----------
 

--- a/RST/en/SWDesignAndDataStructs/ContentStyle.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentStyle.rst
@@ -10,17 +10,6 @@
 Style and Documentation: Introduction
 =====================================
 
-..
-    Shortcuts
-    ---------
-    
-    - :ref:`introduction`
-    - :ref:`ContentStyleNaming`
-    - :ref:`ContentStyleFormat`
-    - :ref:`ContentStyleDocumentation`
-    - :ref:`ContentStyleOther`
-    - :ref:`ContentStyleReview`
-
 Overview & Objectives
 ---------------------
 *Upon completion of this module, students will be able to:*

--- a/RST/en/SWDesignAndDataStructs/ContentTrees.rst
+++ b/RST/en/SWDesignAndDataStructs/ContentTrees.rst
@@ -10,17 +10,6 @@
 Trees
 =========================
 
-..
-    Shortcuts
-    ---------
-    
-    - :ref:`TreeIntro`
-    - :ref:`TreeBinTree`
-    - :ref:`TreeTraverse`
-    - :ref:`TreeProg`
-
-
-
 Objectives
 ----------------------
 


### PR DESCRIPTION
Turns out the internal links don’t work when used inside an LTI page. Browsers want to open the page direct from OpenDSA instead of Canvas linking within the iFrame.

Possible to recreate with raw html, but that is a huge time sink, and not terribly reliable.