### PR TITLE
Upgrade Sphinx to 8.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:22-alpine3.20 AS node
-FROM python:3.9-alpine3.20
+FROM python:3.13-alpine3.20
 
 ARG ODSA_ENV="DEV"
 ENV ODSA_ENV=${ODSA_ENV}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.8.2
 xmltodict==0.12.0
 docutils==0.21
-sphinx==8.1
+sphinx==8.2
 hieroglyph==2.1.0
 pylint==2.5.3
 Flask==2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.8.2
 xmltodict==0.12.0
 docutils==0.21
-sphinx==8.0
+sphinx==8.1
 hieroglyph==2.1.0
 pylint==2.5.3
 Flask==2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.8.2
 xmltodict==0.12.0
-docutils==0.19
-sphinx==7.0
+docutils==0.21
+sphinx==8.0
 hieroglyph==2.1.0
 pylint==2.5.3
 Flask==2.0.3


### PR DESCRIPTION
Upgrade OpenDSA to the latest **stable** release of Sphinx (8.2.0). Sphinx 8.3.0 is currently in development and unstable, so as of now we should not upgrade further. 
From the books I have tried (Test, CS2, CS3, PIFLA, and SWDesignAndDataStructs), there are no issues at all. I also have not noticed any new warnings or errors (besides the codeincludes warnings we discussed yesterday). I also compared each of those books to the ones on the OpenDSA server, and everything seems to match from what I have compared thus far.

There were pretty much no major changes after the Sphinx 7.0 upgrade; the only necessary changes were: 
1)	Updating Python (in Dockerfile) to latest version; Python 3.9 became deprecated in Sphinx 8.0.0
2)	Updating docutils to 0.21; 0.19 became deprecated in Sphinx 8.0.0

Because the Dockerfile was updated, it is necessary to run **docker compose build,** otherwise users will experience errors when trying to make a book. I submitted a PR for this update – let me know if you happen to find any issues with the updates. 