### PR TITLE
Scroll Depth Tracking Implementation - Canvas LTI Environment (Staging Testing)

### DIFF
--- a/tools/config_templates.py
+++ b/tools/config_templates.py
@@ -13,58 +13,58 @@ rst_header = '''\
 
 rst_footer = '''\
  .. raw:: html
- 
+
     <script type="text/javascript">
      $(function () {
        var moduleName = "%(module_name)s";
        var sections = %(sections)s;
+       
        TimeMe.initialize({
          idleTimeoutInSeconds: 10
        });
        sections.forEach(function (section, i) {
          TimeMe.trackTimeOnElement(section);
        });
+       
        var timeObj = {};
        setInterval(function () {
          timeObj[moduleName.substring(0, 5)] = TimeMe.getTimeOnCurrentPageInSeconds().toFixed(2);
          sections.forEach(function (section, i) {
            timeObj[i + "-" + section.substring(0, 5)] = TimeMe.getTimeOnElementInSeconds(section).toFixed(2);
          });
-         for (var sec of sections) {
-         }
        }, 2000);
        
-       // Initialize scroll depth tracking
-       if (typeof $.scrollDepth === 'function') {
-         $.scrollDepth({
-           minHeight: 0,
-           elements: sections,
-           percentage: true,
-           userTiming: true,
-           pixelDepth: true,
-           nonInteraction: true,
-           eventHandler: function(data) {
-             // Check if ODSA.UTILS exists before calling
-             if (typeof ODSA !== 'undefined' && ODSA.UTILS && typeof ODSA.UTILS.logUserAction === 'function') {
-               ODSA.UTILS.logUserAction(
-                 'scroll', 
-                 {
-                   percentage: data.eventLabel, 
-                   pixelDepth: data.pixelDepth,
-                   timing: data.eventTiming,
-                   element: data.eventAction || null
-                 },
-                 null,
-                 null
-               );
-             } else {
-               console.warn('ODSA.UTILS.logUserAction not available for scroll logging');
-             }
+       // Scroll depth tracking implementation
+       // Force iframe to have its own scroller
+       window.addEventListener('load', function() {
+         // Ensure iframe content is always scrollable
+         document.body.style.minHeight = '150vh'; // Force content to be taller
+         document.body.style.overflow = 'auto';   // Ensure scrolling enabled
+         document.documentElement.style.overflow = 'auto';
+         
+         // Prevent Canvas from hijacking scroll
+         var maintainScroller = setInterval(function() {
+           if (document.body.scrollHeight <= window.innerHeight) {
+             document.body.style.minHeight = (window.innerHeight + 500) + 'px';
            }
-         });
-       } else {
-         console.warn('jQuery scrollDepth plugin not loaded - scroll tracking disabled');
-       }
+         }, 1000);
+         
+         // Initialize ScrollDepth after ensuring scroller exists
+         setTimeout(function() {
+           if (typeof $.scrollDepth === 'function' && typeof ODSA !== 'undefined' && ODSA.UTILS) {
+             $.scrollDepth({
+               percentage: true,
+               eventHandler: function(data) {
+                 ODSA.UTILS.logUserAction('scroll', {
+                   percentage: data.eventLabel,
+                   pixelDepth: data.pixelDepth,
+                   timing: data.eventTiming
+                 }, null, null);
+               }
+             });
+           }
+         }, 2000);
+       });
      });
     </script>
  '''


### PR DESCRIPTION
## Implementation
- Forces iframe to maintain internal scroller through `minHeight: 150vh`
- Continuous monitoring (1-second intervals) to prevent Canvas resizing

## Current Limitations & Caveats
- Primary Issue: Users see two scrollers - Canvas main page and iframe content
- Tracking Limitation: Only iframe scrolling is tracked, Canvas scrolling is not
- So users who primarily use Canvas scroller will have no scroll data logged
-  Oversized Scroll Area: iframe content forced to 150% viewport height makes scrollbar very long
- Early Milestone Triggers: 25% and 50% milestones may be reached too quickly with minimal scrolling

## Testing Status
- Scroll events successfully logged to localStorage  
- No JavaScript errors in Canvas environment  
- Compatible with existing OpenDSA logging infrastructure  

