### PR TITLE
Fix widget to check complete_flag instead of attempt_flag

### DIFF
--- a/tools/postprocessor.py
+++ b/tools/postprocessor.py
@@ -474,7 +474,7 @@ function toggleExerciseWidget(widgetId) {{
 }}
 
 if (typeof ODSA !== 'undefined' && ODSA.TP && ODSA.TP.courseOfferingId) {{
-    fetch('/course_offerings/' + ODSA.TP.courseOfferingId + '/exercise_list')
+    fetch('/course_offerings/' + ODSA.TP.courseOfferingId + '/exercise_list?check_proficiency=true')
         .then(function(response) {{ return response.json(); }})
         .then(function(data) {{
             var exerciseAttempts = data.odsa_exercise_attempts;


### PR DESCRIPTION
- Modified `postprocessor.py` to check for `complete_flag`
- Widget now should count exercises as complete when proficient (not just attempted)