### PR TITLE
PRQuadTree Remove: one click per point

### DIFF
--- a/AV/Spatial/PRquadtreeInter.js
+++ b/AV/Spatial/PRquadtreeInter.js
@@ -28,19 +28,23 @@ $(document).ready(function() {
 
   function removeAtPosition(pageX, pageY) {
     var point = new Point(pageX - clickOffsetX, pageY - clickOffsetY, "•");
-    bint.remove(point, txt);
+    return bint.remove(point, txt);
   }
 
   $('#container').mousedown(function(e) {
     if (insertMode === 2) {
       isDragging = true;
-      removeAtPosition(e.pageX, e.pageY);
+      if (removeAtPosition(e.pageX, e.pageY)) {
+        isDragging = false;
+      }
     }
   });
 
   $('#container').mousemove(function(e) {
     if (isDragging && insertMode === 2) {
-      removeAtPosition(e.pageX, e.pageY);
+      if (removeAtPosition(e.pageX, e.pageY)) {
+        isDragging = false;
+      }
     }
   });
 

--- a/DataStructures/PRquadtree.js
+++ b/DataStructures/PRquadtree.js
@@ -51,10 +51,12 @@
 	QuadTreeProto.remove = function(point) {
 	  if (point.getX() < 0 || point.getX() > 256 ||
 	    point.getY() < 0 || point.getY() > 256) {
-	    return;
+	    return false;
 	  }
+	  this.qdt.lastRemoved = false;
 	  this.underRoot = this.underRoot.remove(this.qdt.root(), point, 0, 0, 256, 256, this.pte);
 	  this.qdt.layout();
+	  return this.qdt.lastRemoved;
 	}
 
 
@@ -188,6 +190,7 @@
 	    var label = this.list[index + 2];
 	    //this.list.splice(index, 2);
 	    this.current -= 3;
+	    this.qdt.lastRemoved = true;
 	  } else {
 	    if (noClick) {
 	      this.jsav.step();


### PR DESCRIPTION
This is an update to #753. The user will still be able to click and drag their mouse to remove a point, but each click only removes one point. The user has to click the mouse button again to get another point to remove.