### PR TITLE
Add auto-refresh for exercise progress widget

### DIFF
--- a/lib/odsaKA.js
+++ b/lib/odsaKA.js
@@ -674,7 +674,7 @@
       if (current_progress >= threshold && MODULE_ORIGIN !== "") {
         Khan.proficiency = true;
         // TODO: recheck what is the purpose of sending this to the parent
-        parent.postMessage('{"exercise":"' + exerciseName + '","proficient":' + true + ',"error":' + false + '}', MODULE_ORIGIN);
+        parent.postMessage('{"exercise":"' + Khan.exerciseName + '","proficient":' + true + ',"error":' + false + '}', MODULE_ORIGIN);
 
         // send score to canvas
         // if (data.was_proficient === false && toolProviderData.outcomeService && !toolProviderData.instChapterModuleId) {

--- a/lib/odsaKA.js
+++ b/lib/odsaKA.js
@@ -674,7 +674,7 @@
       if (current_progress >= threshold && MODULE_ORIGIN !== "") {
         Khan.proficiency = true;
         // TODO: recheck what is the purpose of sending this to the parent
-        // parent.postMessage('{"exercise":"' + exerciseName + '","proficient":' + true + ',"error":' + false + '}', MODULE_ORIGIN);
+        parent.postMessage('{"exercise":"' + exerciseName + '","proficient":' + true + ',"error":' + false + '}', MODULE_ORIGIN);
 
         // send score to canvas
         // if (data.was_proficient === false && toolProviderData.outcomeService && !toolProviderData.instChapterModuleId) {


### PR DESCRIPTION
- In odsaKA.js: uncomment parent.postMessage to forward KA exercise completion to the parent page, enabling the auto-refresh chain for multiple choice and true/false exercises

Note: The `odsa-exercise-complete` custom event dispatch in `odsaMOD.js` was already present in master from a previous commit, so only `odsaKA.js` is included in this PR.

## Status / Feedback Requested
Auto-refresh works for non-KA exercises  via the custom `odsa-exercise-complete` event dispatched in `updateProfDisplay` in
`odsaMOD.js`. However, KA exercises are not triggering the refresh — the `parent.postMessage` in `odsaKA.js` does not appear to be reaching the parent page, possibly due to iframe cross-origin restrictions. Looking for guidance on the correct way to forward KA exercise completion signals to the parent page.

## Just a Note on Base Branch
This PR targets `master`. When attempting to target `staging`, the diff showed 1,480+ files changed due to difference between the `staging` branch and the local `Brodish-staging` branch used for development. 

