### PR TITLE
Add node dragging as optional property to base graph class

### DIFF
--- a/AV/Graph/BFSPE.js
+++ b/AV/Graph/BFSPE.js
@@ -10,6 +10,7 @@
 
   jsav.recorded();
 
+//-----------------------------
   function init() {
     // create the graph
     if (graph) {
@@ -19,10 +20,12 @@
       width: 400,
       height: 400,
       layout: "automatic",
-      directed: false
+      directed: false,
+      draggable: true
     });
     graphUtils.generate(graph); // Randomly generate the graph without weights
     graph.layout();
+    
     // mark the "A" node
     graph.nodes()[0].addClass("marked");
 

--- a/AV/Graph/DFSPE.js
+++ b/AV/Graph/DFSPE.js
@@ -9,7 +9,6 @@ $(document).ready(function() {
       jsav = new JSAV($(".avcontainer"), {settings: settings});
 
   jsav.recorded();
-
   function init() {
     // create the graph
     if (graph) {
@@ -19,10 +18,12 @@ $(document).ready(function() {
       width: 400,
       height: 400,
       layout: "automatic",
-      directed: false
+      directed: false,
+      draggable: true
     });
     graphUtils.generate(graph); // Randomly generate the graph without weights
     graph.layout();
+    
     // mark the 'A' node
     graph.nodes()[0].addClass("marked");
 

--- a/AV/Graph/DijkstraPE.js
+++ b/AV/Graph/DijkstraPE.js
@@ -19,10 +19,12 @@
       width: 400,
       height: 400,
       layout: "automatic",
-      directed: false
+      directed: false,
+      draggable: true
     });
     graphUtils.generate(graph, {weighted: true}); // Randomly generate the graph with weights
     graph.layout();
+    
     // mark the 'A' node
     graph.nodes()[0].addClass("marked");
 

--- a/AV/Graph/KruskalPE.js
+++ b/AV/Graph/KruskalPE.js
@@ -17,7 +17,8 @@
       width: 400,
       height: 400,
       layout: "automatic",
-      directed: false
+      directed: false,
+      draggable: true
     });
     graphUtils.generate(graph, {
       weighted: true,

--- a/AV/Graph/PrimPE.js
+++ b/AV/Graph/PrimPE.js
@@ -19,10 +19,12 @@
       width: 400,
       height: 400,
       layout: "automatic",
-      directed: false
+      directed: false,
+      draggable: true
     });
     graphUtils.generate(graph, {weighted: true}); // Randomly generate the graph with weights
     graph.layout();
+
     // mark the 'A' node
     graph.nodes()[0].addClass("marked");
 

--- a/lib/JSAV.js
+++ b/lib/JSAV.js
@@ -6721,7 +6721,7 @@ if (typeof Raphael !== "undefined") { // only execute if Raphael is loaded
     this._alledges = null;
     return [oldadj, index, options];
   });
-
+//-----------------------code I made changes to-----------------------
   // returns a new graph node
   graphproto.newNode = function (value, options) {
     var newNode = new GraphNode(this, value, options), // create new node
@@ -6729,13 +6729,42 @@ if (typeof Raphael !== "undefined") { // only execute if Raphael is loaded
     newNodes.push(newNode); // add new node to clone of node array
     // set the nodes (makes the operation animatable
     this._setnodes(newNodes, options);
-
+  
     var newAdjs = this._edges.slice(0);
     newAdjs.push([]);
     this._setadjs(newAdjs, options);
-
+  
+    // Enable node dragging if draggable option is set
+    if (this.options.draggable) {
+      var graph = this;
+      newNode.element.draggable({
+        start: function(event, ui) {
+          // Slow down animation during drag
+          $(document).trigger("jsav-speed-change", 50);
+        },
+        drag: function(event, ui) {
+          // Redraw edges connected to the dragged node
+          var dragNode = $(this).data("node");
+          var edges = graph.edges();
+          for (var i = 0; i < edges.length; i++) {
+            var edge = edges[i];
+            if (edge.start().id() === dragNode.id() ||
+                edge.end().id() === dragNode.id()) {
+              edge.layout();
+            }
+          }
+        },
+        stop: function(event, ui) {
+          // Restore animation speed after drag
+          $(document).trigger("jsav-speed-change", JSAV.ext.SPEED);
+        },
+        containment: "parent" // Keep nodes within graph bounds
+      });
+    }
+  
     return newNode;
   };
+  //--------------------------------end of code I made changes to-----------------------
   graphproto.addNode = function (value, options) {
     return this.newNode(value, options);
   };


### PR DESCRIPTION
Added node dragging as an optional property to the base graph class in lib/JSAV.js. When draggable: true is passed as an option, nodes can be dragged and edges automatically redraw to follow. The implementation is based on the existing dragging code in DataStructures/FLA/FA.js.

Enabled dragging in the following exercises:
DFS Search (DFSPE.js)
BFS Search (BFSPE.js)
Dijkstra's Shortest Paths (DijkstraPE.js)
Prim's MCST (PrimPE.js)
Kruskal's MCST (KruskalPE.js)