### PR TITLE
fix: sanitize tab hrefs before jQuery UI init to fix Canvas fragment 

### DIFF
--- a/RST/ODSAextensions/odsa/codeinclude/codeinclude.py
+++ b/RST/ODSAextensions/odsa/codeinclude/codeinclude.py
@@ -165,13 +165,19 @@ class codeinclude(Directive):
         #TEMPORARY FIX: ARIA lables were nested and the DevTools were raising accessibility issues.
         # This fix moves the ARIA atributes from <li> to <a> which fixes the nexting issue. 
         html_strs[-1] += '</div><script>$(function() {' \
+          '$( "#%s > ul > li > a" ).each(function() {' \
+            'var href = $(this).attr("href");' \
+            'if (href && href.indexOf("#") !== -1) {' \
+              '$(this).attr("href", "#" + href.split("#").pop());' \
+            '}' \
+          '});' \
           '$( "#%s" ).tabs();' \
           '$( "#%s > ul > li" ).each(function() {' \
             'var $li = $(this), $a = $li.children("a");' \
             '$a.attr({"role": "tab", "tabindex": $li.attr("tabindex"), "aria-controls": $li.attr("aria-controls"), "aria-selected": $li.attr("aria-selected")});' \
             '$li.attr("role", "presentation").removeAttr("tabindex aria-controls aria-selected aria-labelledby aria-expanded");' \
           '});' \
-        '});</script>' % (tab_id, tab_id)
+        '});</script>' % (tab_id, tab_id, tab_id)
 
     # If only one code block exists, print the code normally
     if len(code_nodes) == 1:


### PR DESCRIPTION
fixes: jQuery UI Tabs mismatching fragment identifier in Canvas mode
when a book is compiled for Canvas, code blocks with multiple language tabs only display the first tab. clicking any other tab throws:
Uncaught Error: jQuery UI Tabs: Mismatching fragment identifier.
Canvas sets a <base href> pointing to its own URL (e.g. https://canvas.instructure.com/courses/123/...). when jQuery UI Tabs initializes, it resolves each tab's href="#panel-id" against this base URL, producing a full Canvas URL + fragment. it then fails to find a matching panel in the local DOM and throws the error. standalone mode is unaffected because no base href is set there.
in codeinclude.py, before calling .tabs(), added a small jQuery snippet that strips everything before # in each tab anchor's href, ensuring jQuery UI always receives a clean local fragment regardless of what the base URL is set to.