### PR TITLE
Correct spelling of "executed" in multiple files

### DIFF
--- a/Exercises/RecurTutor/RectFIBasterisk.html
+++ b/Exercises/RecurTutor/RectFIBasterisk.html
@@ -31,7 +31,7 @@ void asterisksPrinter(int i) {
           <p class="solution" data-type="text"><var>ANS</var></p>
           <div class="hints">
             <p> Note that there are two recursive calls.</p>
-            <p>Don't forget that the print statement will be exectued
+            <p>Don't forget that the print statement will be executed
               on the rollback for EACH of the recursive calls.</p>
           </div>
         </div>

--- a/Exercises/RecurTutor/RectFIBcount.html
+++ b/Exercises/RecurTutor/RectFIBcount.html
@@ -25,7 +25,7 @@ public void dosomething (int n) {
           </p>
           <p class="solution" data-type="text">12345</p>
           <div class="hints">
-            <p>The print command will be exectued when the recursive
+            <p>The print command will be executed when the recursive
               call reaches the base case, and then each time coming
               back back.</p>
           </div> 

--- a/Exercises/RecurTutor/RectFIBcountdown.html
+++ b/Exercises/RecurTutor/RectFIBcountdown.html
@@ -25,7 +25,7 @@ public void dosomething (int n) {
           </p>
           <p class="solution" data-type="text">54321</p>
           <div class="hints">
-            <p>The print command will be exectued before the recursive
+            <p>The print command will be executed before the recursive
               call, each time until it reaches the base case.</p>
           </div> 
         </div>

--- a/Exercises/RecurTutor/RectMCQprintstring.html
+++ b/Exercises/RecurTutor/RectMCQprintstring.html
@@ -29,7 +29,7 @@ void printString(String s) {
         <li>It prints only the last character of string s.</li>
       </ul>
       <div class="hints">
-        <p>Note that the print command is exectued after the base case
+        <p>Note that the print command is executed after the base case
           is reached when unwinding the recursion.</p> 
       </div>
     </div>

--- a/RST/en/Tutorials/cmdline.rst
+++ b/RST/en/Tutorials/cmdline.rst
@@ -24,7 +24,7 @@ What's A CLI?
 
 A Command Line Interface or CLI is a simple text only interface. A user provides
 a command with or without some additional information and then the command is
-exectued.
+executed.
 
 Basics:
 


### PR DESCRIPTION
While studying the material, I noticed that the word "executed" was misspelled in section 3.1, "Command Line Basics" I also found a few other occurrences of the same typo, which have been fixed in this PR.