### PR TITLE
Move drag implementation to base graph class, FA now inherits dragging from graph

### DIFF
--- a/DataStructures/FLA/FA.js
+++ b/DataStructures/FLA/FA.js
@@ -228,19 +228,13 @@ var lambda = String.fromCharCode(955),
     } else {
       value = options.value;
     }
+    //-----------------------code I made changes to(Jun 08 2026)(Ashwin Nimmala)-----------------------
     var newNode = this.newNode(value, options);
     newNode.automaton = this;
-      newNode.element.draggable({
-        start: dragStart,
-        stop: dragStop,
-        drag: dragging,
-        containment: "parent"
-      });
-      if (!this.isDraggable) {
-        newNode.element.draggable('disable');
-      } else {
-        newNode.element.draggable('enable');
-      }
+    if (!this.isDraggable) {
+      newNode.element.draggable('disable');
+    }
+    //----------------------- end of code I made changes to(Jun 08 2026)(Ashwin Nimmala)-----------------------
     if (this.editable) {
       newNode.element.contextmenu(function (e) {
         newNode.showMenu(e);
@@ -2080,178 +2074,181 @@ var lambda = String.fromCharCode(955),
       l1 = l2 - 10;
     this._initialMarker = this.jsav.g.line(l1, t, l2, t, $.extend({ "stroke-width": 5, "arrow-end": "block-wide-short" }, options));
   };
+//-----------------------code I made changes to(Jun 08 2026)(Ashwin Nimmala)-----------------------
+// Drag functions removed - now inherited from base graph class in JSAV.js
+  
+// // draggable functions
+  // // edited by Peixuan Ge (6/14/2020) to solve the problem
+  // // that a FiniteAutomaton graph would mess up if any node is dragged
+  // var animStacks = [];
 
-  // draggable functions
-  // edited by Peixuan Ge (6/14/2020) to solve the problem
-  // that a FiniteAutomaton graph would mess up if any node is dragged
-  var animStacks = [];
+  // /*
+  // * Function to back up all the animation of a jsav to the parameter above.
+  // * This is used to solve problem that dragging node may mess up the graph.
+  // */
+  // function backupAnimStacks(av) {
+  //   // if the animation stacks are already backuped, return this function.
+  //   for(i = 0 ; i < animStacks.length ; i++){
+  //     if(animStacks[i].jsav == av){
+  //       return;
+  //     }
+  //   }
+  //   // else push a deep copy of the animations stacks to the parameter above.
+  //   var anAnimStack = [];
+  //   var i, temp;
+  //   for(i = 0 ; i < av._undo.length ; i++){
+  //     temp = [];
+  //     av._undo[i].operations.forEach((item) => {
+  //       temp.push(item);
+  //     });
+  //     anAnimStack.push(temp);
+  //   }
+  //   for(i = 0 ; i < av._redo.length ; i++){
+  //     temp = [];
+  //     av._redo[i].operations.forEach((item) => {
+  //       temp.push(item);
+  //     });
+  //     anAnimStack.push(temp);
+  //   }
+  //   animStacks.push({
+  //     "animStack" : anAnimStack,
+  //     "jsav" : av
+  //   });
+  // }
 
-  /*
-  * Function to back up all the animation of a jsav to the parameter above.
-  * This is used to solve problem that dragging node may mess up the graph.
-  */
-  function backupAnimStacks(av) {
-    // if the animation stacks are already backuped, return this function.
-    for(i = 0 ; i < animStacks.length ; i++){
-      if(animStacks[i].jsav == av){
-        return;
-      }
-    }
-    // else push a deep copy of the animations stacks to the parameter above.
-    var anAnimStack = [];
-    var i, temp;
-    for(i = 0 ; i < av._undo.length ; i++){
-      temp = [];
-      av._undo[i].operations.forEach((item) => {
-        temp.push(item);
-      });
-      anAnimStack.push(temp);
-    }
-    for(i = 0 ; i < av._redo.length ; i++){
-      temp = [];
-      av._redo[i].operations.forEach((item) => {
-        temp.push(item);
-      });
-      anAnimStack.push(temp);
-    }
-    animStacks.push({
-      "animStack" : anAnimStack,
-      "jsav" : av
-    });
-  }
+  // /*
+  // * Function to restore all the animation of a jsav.
+  // * This is used to solve problem that dragging node may mess up the graph.
+  // * Dragging node would mess up the animation stacks,
+  // * this function can restore them and
+  // * should always run after the backup is called.
+  // */
+  // function restoreAnimStacks(av) {
+  //   var i, j;
+  //   // check if a jsav is backuped
+  //   for(i = 0 ; i < animStacks.length ; i++){
+  //     if(animStacks[i].jsav == av){
+  //       var animStack = animStacks[i].animStack;
+  //       //if an extra unnecessary animation is inserted to the stack, remove it
+  //       if(av._undo.length + av._redo.length !== animStack.length){
+  //         av._undo.shift();
+  //         for(j = 0 ; j < av._redo.length ; j++){
+  //           //must create new object here
+  //           av._redo[j].operations = [];
+  //           animStack[j].forEach((item) => {
+  //             av._redo[j].operations.push(item)
+  //           });
+  //         }
+  //       }
+  //       else{
+  //         //restore the animation stacks
+  //         var stackIndex = 0;
+  //         for(j = 0 ; j < av._undo.length ; j++){
+  //           av._undo[j].operations = [];
+  //           animStack[stackIndex].forEach((item) => {
+  //             av._undo[j].operations.push(item)
+  //           });
+  //           stackIndex++;
+  //         }
+  //         for(j = 0 ; j < av._redo.length ; j++){
+  //           av._redo[j].operations = [];
+  //           animStack[stackIndex].forEach((item) => {
+  //             av._redo[j].operations.push(item)
+  //           });
+  //           stackIndex++
+  //         }
+  //       }
+  //       return;
+  //     }
+  //   }
+  //   console.error("restoreAnimFailed");
+  // }
 
-  /*
-  * Function to restore all the animation of a jsav.
-  * This is used to solve problem that dragging node may mess up the graph.
-  * Dragging node would mess up the animation stacks,
-  * this function can restore them and
-  * should always run after the backup is called.
-  */
-  function restoreAnimStacks(av) {
-    var i, j;
-    // check if a jsav is backuped
-    for(i = 0 ; i < animStacks.length ; i++){
-      if(animStacks[i].jsav == av){
-        var animStack = animStacks[i].animStack;
-        //if an extra unnecessary animation is inserted to the stack, remove it
-        if(av._undo.length + av._redo.length !== animStack.length){
-          av._undo.shift();
-          for(j = 0 ; j < av._redo.length ; j++){
-            //must create new object here
-            av._redo[j].operations = [];
-            animStack[j].forEach((item) => {
-              av._redo[j].operations.push(item)
-            });
-          }
-        }
-        else{
-          //restore the animation stacks
-          var stackIndex = 0;
-          for(j = 0 ; j < av._undo.length ; j++){
-            av._undo[j].operations = [];
-            animStack[stackIndex].forEach((item) => {
-              av._undo[j].operations.push(item)
-            });
-            stackIndex++;
-          }
-          for(j = 0 ; j < av._redo.length ; j++){
-            av._redo[j].operations = [];
-            animStack[stackIndex].forEach((item) => {
-              av._redo[j].operations.push(item)
-            });
-            stackIndex++
-          }
-        }
-        return;
-      }
-    }
-    console.error("restoreAnimFailed");
-  }
+  // //variable to store FAs that have any node changed
+  // var nodeChangedAutomaton = [];
+  // /*
+  // * Function to add event listeners to all the jsav control buttons.
+  // * Give them extra tasks to layout the graph
+  // * and restore the animation animStacks.
+  // * (This is an alternative approach to fix the problem, and not the best way.
+  // * Hopefully someone can finish this in the future.)
+  // */
+  // function addLayoutListeners(av, node) {
+  //   //check if a FiniteAutomaton is already patched
+  //   //if not add listeners to jsav control buttons and record that FA
+  //   if(!nodeChangedAutomaton.includes(node.automaton)){
+  //     nodeChangedAutomaton.push(node.automaton);
+  //     $("#" + av.container[0].id + " .jsavbegin").click(function() {
+  //         node.automaton.layout();
+  //         restoreAnimStacks(av);
+  //     })
+  //     $("#" + av.container[0].id + " .jsavbackward").click(function() {
+  //         node.automaton.layout();
+  //         restoreAnimStacks(av);
+  //     })
+  //     $("#" + av.container[0].id + " .jsavforward").click(function() {
+  //         node.automaton.layout();
+  //         restoreAnimStacks(av);
+  //     })
+  //     $("#" + av.container[0].id + " .jsavend").click(function() {
+  //         node.automaton.layout();
+  //         restoreAnimStacks(av);
+  //     })
+  //   }
+  // }
 
-  //variable to store FAs that have any node changed
-  var nodeChangedAutomaton = [];
-  /*
-  * Function to add event listeners to all the jsav control buttons.
-  * Give them extra tasks to layout the graph
-  * and restore the animation animStacks.
-  * (This is an alternative approach to fix the problem, and not the best way.
-  * Hopefully someone can finish this in the future.)
-  */
-  function addLayoutListeners(av, node) {
-    //check if a FiniteAutomaton is already patched
-    //if not add listeners to jsav control buttons and record that FA
-    if(!nodeChangedAutomaton.includes(node.automaton)){
-      nodeChangedAutomaton.push(node.automaton);
-      $("#" + av.container[0].id + " .jsavbegin").click(function() {
-          node.automaton.layout();
-          restoreAnimStacks(av);
-      })
-      $("#" + av.container[0].id + " .jsavbackward").click(function() {
-          node.automaton.layout();
-          restoreAnimStacks(av);
-      })
-      $("#" + av.container[0].id + " .jsavforward").click(function() {
-          node.automaton.layout();
-          restoreAnimStacks(av);
-      })
-      $("#" + av.container[0].id + " .jsavend").click(function() {
-          node.automaton.layout();
-          restoreAnimStacks(av);
-      })
-    }
-  }
+  // //Peixuan added backupAnimStacks function
+  // function dragStart(event, node) {
+  //   backupAnimStacks(node.helper.data("node").automaton.jsav);
+  //   $(document).trigger("jsav-speed-change", 50);
+  //   var dragNode = node.helper.data("node");
+  //   dragNode.wasHighlighted = dragNode.hasClass("jsavhighlight");
+  //   dragNode.highlight();
+  // };
 
-  //Peixuan added backupAnimStacks function
-  function dragStart(event, node) {
-    backupAnimStacks(node.helper.data("node").automaton.jsav);
-    $(document).trigger("jsav-speed-change", 50);
-    var dragNode = node.helper.data("node");
-    dragNode.wasHighlighted = dragNode.hasClass("jsavhighlight");
-    dragNode.highlight();
-  };
+  // //Peixuan added restoreAnimStacks and addLayoutListeners functions
+  // function dragStop(event, node) {
+  //   var dragNode = node.helper.data("node");
+  //   if (!dragNode.wasHighlighted) {
+  //     dragNode.unhighlight();
+  //   }
+  //   $(document).trigger("jsav-speed-change", JSAV.ext.SPEED);
+  //   restoreAnimStacks(dragNode.automaton.jsav);
+  //   addLayoutListeners(dragNode.automaton.jsav, dragNode);
+  // };
 
-  //Peixuan added restoreAnimStacks and addLayoutListeners functions
-  function dragStop(event, node) {
-    var dragNode = node.helper.data("node");
-    if (!dragNode.wasHighlighted) {
-      dragNode.unhighlight();
-    }
-    $(document).trigger("jsav-speed-change", JSAV.ext.SPEED);
-    restoreAnimStacks(dragNode.automaton.jsav);
-    addLayoutListeners(dragNode.automaton.jsav, dragNode);
-  };
+  // function dragging(event, node) {
+  //   var dragNode = node.helper.data("node");
+  //   g = dragNode.automaton;
+  //   if (dragNode == g.initial) {
+  //     if (node.helper.offset().left < 45) {
+  //       node.helper.offset({ left: 45 });
+  //     }
+  //   }
+  //   var nodes = g.nodes();
+  //   var neighbors = dragNode.neighbors();
+  //   nodes.reset();
+  //   for (var next = nodes.next(); next; next = nodes.next()) {
+  //     if (next.neighbors().includes(dragNode)) {
+  //       neighbors.push(next);
+  //     }
+  //   }
+  //   for (var i = 0; i < neighbors.length; i++) {
+  //     var neighbor = neighbors[i];
+  //     var edge1 = g.getEdge(dragNode, neighbor);
+  //     var edge2 = g.getEdge(neighbor, dragNode);
+  //     if (edge1) edge1.layout();
+  //     if (edge2) edge2.layout();
+  //   }
+  //   if (dragNode == g.initial) {
+  //     g.removeInitial(dragNode);
+  //     g.makeInitial(dragNode);
+  //   }
+  //   dragNode.stateLabelPositionUpdate();
+  //   dragNode.element.draggable('enable');
+  // };
 
-  function dragging(event, node) {
-    var dragNode = node.helper.data("node");
-    g = dragNode.automaton;
-    if (dragNode == g.initial) {
-      if (node.helper.offset().left < 45) {
-        node.helper.offset({ left: 45 });
-      }
-    }
-    var nodes = g.nodes();
-    var neighbors = dragNode.neighbors();
-    nodes.reset();
-    for (var next = nodes.next(); next; next = nodes.next()) {
-      if (next.neighbors().includes(dragNode)) {
-        neighbors.push(next);
-      }
-    }
-    for (var i = 0; i < neighbors.length; i++) {
-      var neighbor = neighbors[i];
-      var edge1 = g.getEdge(dragNode, neighbor);
-      var edge2 = g.getEdge(neighbor, dragNode);
-      if (edge1) edge1.layout();
-      if (edge2) edge2.layout();
-    }
-    if (dragNode == g.initial) {
-      g.removeInitial(dragNode);
-      g.makeInitial(dragNode);
-    }
-    dragNode.stateLabelPositionUpdate();
-    dragNode.element.draggable('enable');
-  };
-
+  //-----------------------end of code I made changes to(Jun 08 2026)(Ashwin Nimmala)-----------------------
   //********************************************************************************************************************************* */
   /*
      edge/transition class.

--- a/lib/JSAV.js
+++ b/lib/JSAV.js
@@ -6722,6 +6722,134 @@ if (typeof Raphael !== "undefined") { // only execute if Raphael is loaded
     return [oldadj, index, options];
   });
 //-----------------------code I made changes to-----------------------
+//-----------------------code I made changes to(Jun 08 2026)(Ashwin Nimmala)-----------------------
+
+// Animation stack backup/restore to prevent drag from corrupting JSAV history
+  var animStacks = [];
+
+  /*
+  * Back up all animation stacks of a jsav instance before dragging.
+  */
+  function backupAnimStacks(av) {
+    for (var i = 0; i < animStacks.length; i++) {
+      if (animStacks[i].jsav == av) { return; }
+    }
+    var anAnimStack = [];
+    var temp;
+    for (var i = 0; i < av._undo.length; i++) {
+      temp = [];
+      av._undo[i].operations.forEach(function(item) { temp.push(item); });
+      anAnimStack.push(temp);
+    }
+    for (var i = 0; i < av._redo.length; i++) {
+      temp = [];
+      av._redo[i].operations.forEach(function(item) { temp.push(item); });
+      anAnimStack.push(temp);
+    }
+    animStacks.push({ "animStack": anAnimStack, "jsav": av });
+  }
+
+  /*
+  * Restore all animation stacks after dragging.
+  */
+  function restoreAnimStacks(av) {
+    var i, j;
+    for (i = 0; i < animStacks.length; i++) {
+      if (animStacks[i].jsav == av) {
+        var animStack = animStacks[i].animStack;
+        if (av._undo.length + av._redo.length !== animStack.length) {
+          av._undo.shift();
+          for (j = 0; j < av._redo.length; j++) {
+            av._redo[j].operations = [];
+            animStack[j].forEach(function(item) { av._redo[j].operations.push(item); });
+          }
+        } else {
+          var stackIndex = 0;
+          for (j = 0; j < av._undo.length; j++) {
+            av._undo[j].operations = [];
+            animStack[stackIndex].forEach(function(item) { av._undo[j].operations.push(item); });
+            stackIndex++;
+          }
+          for (j = 0; j < av._redo.length; j++) {
+            av._redo[j].operations = [];
+            animStack[stackIndex].forEach(function(item) { av._redo[j].operations.push(item); });
+            stackIndex++;
+          }
+        }
+        return;
+      }
+    }
+    console.error("restoreAnimFailed");
+  }
+  // Track graphs that have had nodes dragged
+  var nodeChangedGraphs = [];
+
+  /*
+  * Add listeners to JSAV control buttons to re-layout graph after dragging.
+  */
+  function addLayoutListeners(av, graph) {
+    if (!nodeChangedGraphs.includes(graph)) {
+      nodeChangedGraphs.push(graph);
+      $("#" + av.container[0].id + " .jsavbegin").click(function() {
+        graph.layout();
+        restoreAnimStacks(av);
+      });
+      $("#" + av.container[0].id + " .jsavbackward").click(function() {
+        graph.layout();
+        restoreAnimStacks(av);
+      });
+      $("#" + av.container[0].id + " .jsavforward").click(function() {
+        graph.layout();
+        restoreAnimStacks(av);
+      });
+      $("#" + av.container[0].id + " .jsavend").click(function() {
+        graph.layout();
+        restoreAnimStacks(av);
+      });
+    }
+  }
+
+  /*
+  * Drag start handler - backup anim stacks and highlight node.
+  */
+  function graphDragStart(event, ui) {
+    var dragNode = $(this).data("node");
+    backupAnimStacks(dragNode.container.jsav);
+    $(document).trigger("jsav-speed-change", 50);
+    dragNode.wasHighlighted = dragNode.hasClass("jsavhighlight");
+    dragNode.highlight();
+  }
+
+  /*
+  * Drag stop handler - restore anim stacks and unhighlight node.
+  */
+  function graphDragStop(event, ui) {
+    var dragNode = $(this).data("node");
+    if (!dragNode.wasHighlighted) {
+      dragNode.unhighlight();
+    }
+    $(document).trigger("jsav-speed-change", JSAV.ext.SPEED);
+    restoreAnimStacks(dragNode.container.jsav);
+    addLayoutListeners(dragNode.container.jsav, dragNode.container);
+  }
+
+  /*
+  * Dragging handler - redraw edges connected to the dragged node.
+  */
+  function graphDragging(event, ui) {
+    var dragNode = $(this).data("node");
+    var g = dragNode.container;
+    var edges = g.edges();
+    for (var i = 0; i < edges.length; i++) {
+      var edge = edges[i];
+      if (edge.start().id() === dragNode.id() ||
+          edge.end().id() === dragNode.id()) {
+        edge.layout();
+      }
+    }
+  }
+  //----------------------- end of code I made changes to(Jun 08 2026)(Ashwin Nimmala)-----------------------
+
   // returns a new graph node
   graphproto.newNode = function (value, options) {
     var newNode = new GraphNode(this, value, options), // create new node
@@ -6735,32 +6863,14 @@ if (typeof Raphael !== "undefined") { // only execute if Raphael is loaded
     this._setadjs(newAdjs, options);
   
     // Enable node dragging if draggable option is set
-    if (this.options.draggable) {
-      var graph = this;
-      newNode.element.draggable({
-        start: function(event, ui) {
-          // Slow down animation during drag
-          $(document).trigger("jsav-speed-change", 50);
-        },
-        drag: function(event, ui) {
-          // Redraw edges connected to the dragged node
-          var dragNode = $(this).data("node");
-          var edges = graph.edges();
-          for (var i = 0; i < edges.length; i++) {
-            var edge = edges[i];
-            if (edge.start().id() === dragNode.id() ||
-                edge.end().id() === dragNode.id()) {
-              edge.layout();
-            }
-          }
-        },
-        stop: function(event, ui) {
-          // Restore animation speed after drag
-          $(document).trigger("jsav-speed-change", JSAV.ext.SPEED);
-        },
-        containment: "parent" // Keep nodes within graph bounds
-      });
-    }
+  if (this.options.draggable) {
+    newNode.element.draggable({
+      start: graphDragStart,
+      drag: graphDragging,
+      stop: graphDragStop,
+      containment: "parent"
+    });
+  }
   
     return newNode;
   };
@@ -7045,6 +7155,26 @@ if (typeof Raphael !== "undefined") { // only execute if Raphael is loaded
     var layoutAlg = this.options.layout || "_default";
     return this.jsav.ds.layout.graph[layoutAlg](this, options);
   };
+
+  //-----------------------code I made changes to(Jun 08 2026)(Ashwin Nimmala)-----------------------
+  // Enable dragging on all nodes
+  graphproto.enableDragging = function() {
+    this.options.draggable = true;
+    var nodes = this.nodes();
+    for (var i = 0; i < nodes.length; i++) {
+      nodes[i].element.draggable('enable');
+    }
+  };
+
+  // Disable dragging on all nodes
+  graphproto.disableDragging = function() {
+    this.options.draggable = false;
+    var nodes = this.nodes();
+    for (var i = 0; i < nodes.length; i++) {
+      nodes[i].element.draggable('disable');
+    }
+  };
+  //----------------------- end of code I made changes to(Jun 08 2026)(Ashwin Nimmala)-----------------------
 
   var SpringLayout = function (graph, options) {
     this.graph = graph;


### PR DESCRIPTION
Description:
- Following up on PR #758, moved the full drag implementation from DataStructures/FLA/FA.js to the base graph class in lib/JSAV.js.

Changes made:
- Added backupAnimStacks, restoreAnimStacks, addLayoutListeners, graphDragStart, graphDragStop, graphDragging to base graph class in JSAV.js
- Added enableDragging and disableDragging to base graph class
- Removed duplicate drag code from FA.js — FA now inherits dragging from the base graph class
- Tested both FA exercises and all 5 graph exercises (DFS, BFS, Dijkstra's, Prim's, Kruskal's) — all working correctly